### PR TITLE
Added first half of agent CLI parsing + rustfmt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -371,6 +371,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.5.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3135e7ec2ef7b10c6ed8950f0f792ed96ee093fa088608f1c76e569722700c84"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30582fc632330df2bd26877bde0c1f4470d57c582bbc070376afcd04d8cb4838"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ac6a0c7b1a9e9a5186361f67dfa1b88213572f427fb9ab038efb2bd8c582dab"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
+
+[[package]]
 name = "colorchoice"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -934,9 +974,11 @@ dependencies = [
  "bson",
  "bytes",
  "chrono",
+ "clap",
  "dotenv",
  "env_logger",
  "futures",
+ "hpos-hal",
  "log",
  "mongodb",
  "nkeys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
 [workspace.dependencies]
 async-nats = { version = "0.38.0", features = ["service"] }
 tokio = { version = "1", features = ["full"] }
+clap = { version = "4.5.23", features = ["derive"] }
 futures = "0.3.31"
 anyhow = "1.0"
 serde = "1.0.215"

--- a/rust/clients/host_agent/Cargo.toml
+++ b/rust/clients/host_agent/Cargo.toml
@@ -12,6 +12,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 log = { workspace = true }
 dotenv = { workspace = true }
+clap = { workspace = true }
 thiserror = "2.0"
 url = { version = "2", features = ["serde"] }
 bson = { version = "2.6.1", features = ["chrono-0_4"] }
@@ -23,3 +24,4 @@ nkeys = "=0.4.4"
 rand = "0.8.5"
 util_libs = { path = "../../util_libs" }
 workload = { path = "../../services/workload" }
+hpos-hal = { path = "../../hpos-hal" }

--- a/rust/clients/host_agent/src/agent_cli.rs
+++ b/rust/clients/host_agent/src/agent_cli.rs
@@ -47,4 +47,9 @@ pub enum HostCommands {
 pub enum SupportCommands {
     /// Run some basic network connectivity diagnostics.
     NetTest,
+    /// Enable or disable a tunnel for support to control this host remotely.
+    SupportTunnel {
+        #[arg(long)]
+        enable: bool,
+    },
 }

--- a/rust/clients/host_agent/src/agent_cli.rs
+++ b/rust/clients/host_agent/src/agent_cli.rs
@@ -1,0 +1,50 @@
+/// MOdule containing all of the Clap Derive structs/definitions that make up the agent's
+/// command line. To start the agent daemon (usually from systemd), use `host_agent daemonize`.
+use clap::{Parser, Subcommand};
+
+#[derive(Parser)]
+#[command(
+    version,
+    about,
+    author,
+    long_about = "Command line interface for hosting workloads on the Holo Hosting Network"
+)]
+pub struct Root {
+    #[command(subcommand)]
+    pub scope: Option<CommandScopes>,
+}
+
+#[derive(Subcommand, Clone)]
+pub enum CommandScopes {
+    /// Start the Holo Hosting Agent Daemon.
+    Daemonize,
+    /// Commmands for managing this host.
+    Host {
+        #[command(subcommand)]
+        command: HostCommands,
+    },
+    /// Run Diagnostic Commands.
+    Support {
+        #[command(subcommand)]
+        command: SupportCommands,
+    },
+}
+
+/// A set of commands for being able to manage the local host. We may (later) want to gate some
+/// of these behind a global `--advanced` option to deter hosters from certain commands, but in the
+/// meantime, everything is safe to leave open.
+#[derive(Subcommand, Clone)]
+pub enum HostCommands {
+    /// Display information about the current host model.
+    ModelInfo,
+}
+
+// Include a set of useful diagnostic commands to aid support. We should work very hard to keep
+// this to a small number of specifically useful commands (ie, no more than half a dozen) that give
+// results specifically useful to support. We don't want this to become a free-for-all for adding a
+// bunch of magical incantations. Each command should be harmless to run and obvious what it does.
+#[derive(Subcommand, Clone)]
+pub enum SupportCommands {
+    /// Run some basic network connectivity diagnostics.
+    NetTest,
+}

--- a/rust/clients/host_agent/src/gen_leaf_server.rs
+++ b/rust/clients/host_agent/src/gen_leaf_server.rs
@@ -1,6 +1,4 @@
-use util_libs::nats_server::{
-    self, JetStreamConfig, LeafNodeRemote, LeafServer, LoggingOptions,
-};
+use util_libs::nats_server::{self, JetStreamConfig, LeafNodeRemote, LeafServer, LoggingOptions};
 
 const LEAF_SERVE_NAME: &str = "test_leaf_server";
 const LEAF_SERVER_CONFIG_PATH: &str = "test_leaf_server.conf";

--- a/rust/clients/host_agent/src/host_cmds.rs
+++ b/rust/clients/host_agent/src/host_cmds.rs
@@ -1,0 +1,21 @@
+use crate::agent_cli::HostCommands;
+use hpos_hal::inventory::HoloInventory;
+
+pub fn host_command(command: &HostCommands) -> Result<(), std::io::Error> {
+    // TODO: Fill these in under a separate set of commits to keep PRs simple.
+    match command {
+        HostCommands::ModelInfo => {
+            let i = HoloInventory::from_host();
+            //println!("{}", serde_json::to_string(&i).unwrap());
+            match i.platform {
+                Some(p) => {
+                    println!("{}", p)
+                }
+                None => {
+                    println!("No platform information retrieved.")
+                }
+            }
+        }
+    }
+    Ok(())
+}

--- a/rust/clients/host_agent/src/main.rs
+++ b/rust/clients/host_agent/src/main.rs
@@ -15,16 +15,48 @@
 // mod utils;
 mod workloads;
 use anyhow::Result;
+use clap::Parser;
 use dotenv::dotenv;
+pub mod agent_cli;
 pub mod gen_leaf_server;
+pub mod host_cmds;
+pub mod support_cmds;
+use thiserror::Error;
 use util_libs::nats_js_client;
 
+#[derive(Error, Debug)]
+pub enum AgentCliError {
+    #[error("Agent Daemon Error")]
+    AsyncNats(#[from] async_nats::Error),
+    #[error("Command Line Error")]
+    CommandError(#[from] std::io::Error),
+}
+
 #[tokio::main]
-async fn main() -> Result<(), async_nats::Error> {
+async fn main() -> Result<(), AgentCliError> {
     dotenv().ok();
     env_logger::init();
-    log::info!("Spawning host_agent");
 
+    let cli = agent_cli::Root::parse();
+    match &cli.scope {
+        Some(agent_cli::CommandScopes::Daemonize) => {
+            log::info!("Spawning host agent.");
+            daemonize().await?;
+        }
+        Some(agent_cli::CommandScopes::Host { command }) => host_cmds::host_command(command)?,
+        Some(agent_cli::CommandScopes::Support { command }) => {
+            support_cmds::support_command(command)?
+        }
+        None => {
+            log::warn!("No arguments given. Spawning host agent.");
+            daemonize().await?;
+        }
+    }
+
+    Ok(())
+}
+
+async fn daemonize() -> Result<(), async_nats::Error> {
     // let user_creds_path = auth::initializer::run().await?;
     let user_creds_path = "placeholder_creds_that_will_not_be_read".to_string();
     gen_leaf_server::run(&user_creds_path).await;

--- a/rust/clients/host_agent/src/support_cmds.rs
+++ b/rust/clients/host_agent/src/support_cmds.rs
@@ -6,6 +6,14 @@ pub fn support_command(command: &SupportCommands) -> Result<(), std::io::Error> 
         SupportCommands::NetTest => {
             println!("Network Test not yet supported")
         }
+        SupportCommands::SupportTunnel { enable } => {
+            // This is independent of the implementation, which will be plumbed through once we
+            // have an implementation for https://github.com/Holo-Host/holo-host-private/issues/14.
+            match enable {
+                true => { println!("Support Tunnel not yet implemented") }
+                false => { println!("Support Tunnel already disabled") }
+            }
+        }
     }
     Ok(())
 }

--- a/rust/clients/host_agent/src/support_cmds.rs
+++ b/rust/clients/host_agent/src/support_cmds.rs
@@ -1,0 +1,11 @@
+use crate::agent_cli::SupportCommands;
+
+pub fn support_command(command: &SupportCommands) -> Result<(), std::io::Error> {
+    // TODO: Fill these in under a separate set of commits to keep PRs simple.
+    match command {
+        SupportCommands::NetTest => {
+            println!("Network Test not yet supported")
+        }
+    }
+    Ok(())
+}

--- a/rust/hpos-hal/src/inventory.rs
+++ b/rust/hpos-hal/src/inventory.rs
@@ -157,6 +157,15 @@ pub struct HoloPlatform {
     pub hypervisor_guest: bool,
 }
 
+impl Display for HoloPlatform {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "Platform Model: {}\nRunning on Hypervisor: {}",
+            self.platform_type, self.hypervisor_guest
+        )
+    }
+}
 // TODO: This needs more work and testing against real hardware.
 impl HoloPlatform {
     /// Given an inventory structure, use some heuristics to give a best-guess at the type of

--- a/rust/util_libs/src/js_stream_service.rs
+++ b/rust/util_libs/src/js_stream_service.rs
@@ -338,7 +338,6 @@ impl JsStreamService {
     }
 }
 
-
 #[cfg(feature = "tests_integration_nats")]
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
This keeps the current behaviour (for now) of starting the NATS fork/exec path by default when no arguments are specified, but also adds the beginnings of the CLI stuff raised in https://github.com/Holo-Host/holo-host-private/issues/37. I've plumbed through some trivial output for the `model-info` subcommand. I'll plumb through the network test code as a separate pull request, as it will also include a new crate and that'll be easier to review independently. There's a `daemonize` subcommand that the agent's systemd unit can use to start the agent as a daemon and we should look to move toward that, rather than have the daemon the default path.