### PR TITLE
spike to run hivello in a nixos-container (on real hardware)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -306,13 +306,45 @@
         "type": "github"
       }
     },
-    "nixpkgs-unstable": {
+    "nixpkgs-2405": {
       "locked": {
-        "lastModified": 1733581040,
-        "narHash": "sha256-Qn3nPMSopRQJgmvHzVqPcE3I03zJyl8cSbgnnltfFDY=",
+        "lastModified": 1735563628,
+        "narHash": "sha256-OnSAY7XDSx7CtDoqNh8jwVwh4xNL/2HaJxGjryLWzX8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "22c3f2cf41a0e70184334a958e6b124fb0ce3e01",
+        "rev": "b134951a4c9f3c995fd7be05f3243f8ecd65d798",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-24.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2411": {
+      "locked": {
+        "lastModified": 1737885640,
+        "narHash": "sha256-GFzPxJzTd1rPIVD4IW+GwJlyGwBDV1Tj5FLYwDQQ9sM=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "4e96537f163fad24ed9eb317798a79afc85b51b7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-24.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-unstable": {
+      "locked": {
+        "lastModified": 1737885589,
+        "narHash": "sha256-Zf0hSrtzaM1DEz8//+Xs51k/wdSajticVrATqDrfQjg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "852ff1d9e153d8875a83602e03fdef8a63f0ecf8",
         "type": "github"
       },
       "original": {
@@ -330,6 +362,8 @@
         "extra-container": "extra-container",
         "nixago": "nixago",
         "nixpkgs": "nixpkgs",
+        "nixpkgs-2405": "nixpkgs-2405",
+        "nixpkgs-2411": "nixpkgs-2411",
         "nixpkgs-unstable": "nixpkgs-unstable",
         "rust-overlay": "rust-overlay",
         "srvos": "srvos",

--- a/flake.nix
+++ b/flake.nix
@@ -3,6 +3,8 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs?ref=nixos-24.11";
+    nixpkgs-2405.url = "github:NixOS/nixpkgs?ref=nixos-24.05";
+    nixpkgs-2411.url = "github:NixOS/nixpkgs?ref=nixos-24.11";
     nixpkgs-unstable.url = "github:NixOS/nixpkgs?ref=nixos-unstable";
     blueprint.url = "github:numtide/blueprint";
     blueprint.inputs.nixpkgs.follows = "nixpkgs";

--- a/nix/packages/extra-container-hivello.nix
+++ b/nix/packages/extra-container-hivello.nix
@@ -1,0 +1,265 @@
+/*
+  this can be run on a nixos machine (that has extra-containers installed ?) using:
+  $ nix run --refresh github:holo-host/holo-host/hivello-package#extra-container-hivello -- --restart-changed
+
+  it exposes the following services on the host interfaces:
+  * SSH - port TCP 2200 - inherits authorized keys from the host
+  * VNC - port TCP 5900 - unauthenticated
+*/
+
+{
+  flake,
+  inputs,
+  system,
+}:
+
+let
+  nixpkgs = inputs.nixpkgs-2405;
+
+  privateNetwork = false;
+in
+
+(inputs.extra-container.lib.buildContainers {
+
+  # The system of the container host
+  inherit system;
+
+  # Optional: Set nixpkgs.
+  # If unset, the nixpkgs input of extra-container flake is used
+  inherit nixpkgs;
+
+  # Only set this if the `system.stateVersion` of your container
+  # host is < 22.05
+  # legacyInstallDirs = true;
+
+  # Set this to disable `nix run` support
+  # addRunner = false;
+
+  config = {
+    containers.demo = {
+      inherit privateNetwork;
+
+      # `specialArgs` is available in nixpkgs > 22.11
+      # This is useful for importing flakes from modules (see nixpkgs/lib/modules.nix).
+      # specialArgs = { inherit inputs; };
+
+      bindMounts."/etc/ssh/authorized_keys.d/root" = {
+        isReadOnly = true;
+      };
+      bindMounts."/etc/ssh/authorized_keys.d/dev" = {
+        isReadOnly = true;
+        hostPath = "/etc/ssh/authorized_keys.d/root";
+      };
+
+      bindMounts."/dev/dri/renderD128" = {
+        isReadOnly = false;
+      };
+      bindMounts."/dev/dri/card0 " = {
+        isReadOnly = false;
+      };
+      bindMounts."/dev/udmabuf" = {
+        isReadOnly = false;
+      };
+
+      allowedDevices = [
+        {
+          node = "/dev/dri/renderD128";
+          modifier = "rw";
+        }
+        {
+          node = "/dev/dri/card0";
+          modifier = "rw";
+        }
+        {
+          node = "/dev/udmabuf";
+          modifier = "rw";
+        }
+      ];
+
+      # required by podman
+      enableTun = true;
+
+      additionalCapabilities = [
+        # TODO: i saw ptrace used in the strace, not sure if it's a requirement for the happy path
+        "CAP_SYS_PTRACE"
+      ];
+
+      config =
+        {
+          config,
+          pkgs,
+          lib,
+          ...
+        }:
+        {
+          # in case the container shares the host network, don't mess with the firewall rules.
+          networking.firewall.enable = privateNetwork;
+
+          users.users.dev = {
+            isNormalUser = true;
+            home = "/home/dev";
+            extraGroups = [
+              "users"
+              "podman"
+
+              "video"
+              "render"
+
+              # TODO: shouldn't be quired, however i saw something in the logs about it. to get functional KVM there's probably more configuration to apply to the container
+              "kvm"
+            ];
+            createHome = true;
+            linger = true;
+          };
+
+          environment.systemPackages = with pkgs; [
+            flake.packages.${system}.hivello
+
+            glxinfo
+            xterm
+            alacritty
+
+            fluxbox
+            xdg-utils
+
+            (pkgs.writeShellScriptBin "hivello-strace" ''
+              strace --follow-forks --no-abbrev --string-limit=128 --decode-fds=all --decode-pids=comm Hivello "$@" 2>&1 | tee ~/hivello.strace
+            '')
+
+          ];
+
+          programs.nix-ld = {
+            enable = true;
+            libraries =
+              with pkgs;
+              # TODO: not sure if this is required
+              [
+                intel-vaapi-driver
+                libvdpau-va-gl
+                intel-media-driver
+                libva-utils
+              ]
+              ++ flake.packages.${system}.hivello.meta.passthru.dependencies;
+          };
+
+          nix.settings.experimental-features = [
+            "nix-command"
+            "flakes"
+          ];
+
+          programs.turbovnc.ensureHeadlessSoftwareOpenGL = true;
+          hardware.opengl = {
+            enable = true;
+            # TODO: not sure if this is required
+            extraPackages = with pkgs; [
+              mesa.drivers
+              intel-vaapi-driver
+              libvdpau-va-gl
+              intel-media-driver
+              libva.out
+            ];
+          };
+
+          virtualisation.containers.containersConf.settings = {
+            # these work around lack of permissions
+            containers = {
+              keyring = false;
+              pidns = "host";
+            };
+          };
+
+          virtualisation.podman = {
+            enable = true;
+            dockerSocket.enable = true;
+
+            # Create a `docker` alias for podman, to use it as a drop-in replacement
+            dockerCompat = true;
+            # Required for containers under podman-compose to be able to talk to each other.
+            # defaultNetwork.settings = {
+            #   dns_enabled = false;
+            # };
+
+            # optimize later
+            autoPrune.enable = false;
+          };
+
+          programs.firefox.enable = true;
+          fonts = {
+            enableDefaultPackages = true;
+            fontconfig = {
+              defaultFonts = {
+                serif = [
+                  "Liberation Serif"
+                  "Vazirmatn"
+                ];
+                sansSerif = [
+                  "Ubuntu"
+                  "Vazirmatn"
+                ];
+                monospace = [ "Ubuntu Mono" ];
+              };
+            };
+          };
+
+          # this causes the systemd session to start for the user, which will in turn activate the xvnc service.
+          services.getty.autologinUser = "dev";
+          systemd.user.services.xvnc = {
+            unitConfig.ConditionUser = "dev";
+
+            enable = true;
+
+            after = [ "network.target" ];
+            wantedBy = [
+              "default.target"
+              "multi-user.target"
+            ];
+
+            path = config.environment.systemPackages;
+
+            # TODO: not sure if this is required
+            environment.LIBVA_DRIVER_NAME = "iHD";
+
+            script =
+              let
+                xsession = pkgs.writeShellScript "inner" ''
+                  # run a terminal by default.
+                  alacritty &
+
+                  # TODO: fluxbox is rudimentary and we might need something
+                  # richer it works for testing for now.
+                  exec fluxbox
+                '';
+              in
+              builtins.toString (
+                pkgs.writeShellScript "xvnc" ''
+                  set -xeE -o pipefail
+                  ${lib.getExe' pkgs.turbovnc "Xvnc"} :0 \
+                    -iglx -auth $HOME/.Xauthority \
+                    -geometry 1024x768 -depth 24 \
+                    -rfbwait 5000 \
+                    -deferupdate 1 \
+                    -securitytypes none \
+                    -localhost \
+                    &
+                  # Xvnc takes a moment before it can be used
+                  sleep 1
+                  # the wrapper takes care of initialising expected variables for the graphical session
+                  DISPLAY=":0" ${config.services.xserver.displayManager.sessionData.wrapper} ${xsession}
+                ''
+              );
+
+          };
+
+          services.openssh.enable = true;
+          services.openssh.ports = [ 2200 ];
+
+          # disabled in favor of the Xvnc solution
+          services.openssh.settings.X11Forwarding = false;
+        };
+    };
+  };
+
+}).overrideAttrs
+  {
+    meta.platforms = with nixpkgs.lib; lists.intersectLists platforms.linux platforms.x86_64;
+  }

--- a/nix/packages/hivello.nix
+++ b/nix/packages/hivello.nix
@@ -1,0 +1,111 @@
+/*
+  this package wraps the official Hivello release debian package.
+  it currently relies on the nixos config to enable nix-ld with its dependencies installed as libraries.
+
+  see `extra-container-hivello.nix` for a usage reference.
+*/
+
+{
+  inputs,
+  system,
+  ...
+}:
+
+let
+  pkgs = inputs.nixpkgs-2405.legacyPackages.${system};
+  pkgsGbm = inputs.nixpkgs-unstable.legacyPackages.${system};
+  inherit (pkgs)
+    fetchurl
+    lib
+    stdenv
+    ;
+
+  dependencies =
+    with pkgs;
+    [
+
+      alsa-lib
+      at-spi2-atk
+      cairo
+      cups
+      dbus
+      expat
+      gdk-pixbuf
+      glib
+      gtk3
+      nss
+      nspr
+      xorg.libX11
+      xorg.libxcb
+      xorg.libXcomposite
+      xorg.libXdamage
+      xorg.libXext
+      xorg.libXfixes
+      xorg.libXrandr
+      xorg.libxkbfile
+      xorg.libXScrnSaver
+      xorg.libxshmfence
+      pango
+      pciutils
+      stdenv.cc.cc
+      systemd
+      libdrm
+      libxkbcommon
+      libGL
+      vulkan-loader
+      libglvnd
+
+      libgcc.lib
+      expat
+      nss
+      nspr
+
+      mesa
+
+      libgcc.libgcc
+    ]
+    ++ [
+      pkgsGbm.libgbm
+    ];
+
+in
+
+stdenv.mkDerivation {
+  pname = "hivello"; # Replace with your package name
+  version = "1.3.1"; # Replace with your package version
+
+  src = fetchurl {
+    # TODO: get a URL for ${version}
+    url = "https://download.hivello.services/linux/deb/x64"; # Replace with the actual URL
+    sha256 = "sha256-BjJJKMlA83CbHirCmCdnoqdICkslX5FXlIarzm0Pb8s=";
+  };
+
+  nativeBuildInputs = with pkgs; [
+    dpkg
+  ];
+
+  sourceRoot = ".";
+  unpackCmd = ''
+    dpkg-deb -x $src .
+  '';
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    ls -lha
+    mkdir -p $out/bin
+
+    cp -r opt usr $out/
+    ln -s $out/opt/Hivello/Hivello $out/bin/Hivello
+  '';
+
+  meta = with lib; {
+    description = "A brief description of your package.";
+    platforms = lists.intersectLists platforms.linux platforms.x86_64;
+
+    passthru = {
+      inherit dependencies;
+    };
+  };
+}


### PR DESCRIPTION
spike(nix/packages): add hivello extra-container

using the previuosly introduced package, provides nix-ld with its
dependencies installed and runs and exposes Xvnc server to provide a
graphical environment for its exectuion.

---

spike(nix/packages): add hivello

ended up relying on nix-ld because i couldn't figure out exactly which
files needed patching or wrapping in which way.

---

part of https://github.com/holo-host/holo-host-private/issues/94