### PR TITLE
feat: add holochain nixos module, nix extra-container package with test

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -77,6 +77,24 @@
         "type": "github"
       }
     },
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1736143030,
+        "narHash": "sha256-+hu54pAoLDEZT9pjHlqL9DNzWz0NbUn8NEAHP7PQPzU=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "b905f6fc23a9051a6e1b741e1438dbfc0634c6de",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "inputs": {
         "systems": "systems_2"
@@ -167,6 +185,105 @@
       "original": {
         "owner": "numtide",
         "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "hc-launch": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1734474851,
+        "narHash": "sha256-OtXwvb97Qt+xh/K4+voy60kMnpPZvEoqoe2Bgkn+Nro=",
+        "owner": "holochain",
+        "repo": "hc-launch",
+        "rev": "ca598033225d8ee3df7911c1cbde6004182e84eb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "holochain",
+        "ref": "holochain-0.4",
+        "repo": "hc-launch",
+        "type": "github"
+      }
+    },
+    "hc-scaffold": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1739472373,
+        "narHash": "sha256-GetrzMibK/bGPwuj3edooEd38DS9aNqPnhCk0DeJVvo=",
+        "owner": "holochain",
+        "repo": "scaffolding",
+        "rev": "e51aff14dc066c0c87dc8c21dd6ca6b525a011f7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "holochain",
+        "ref": "holochain-0.4",
+        "repo": "scaffolding",
+        "type": "github"
+      }
+    },
+    "holochain": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1738154781,
+        "narHash": "sha256-s011Xzuw4quBGRcv3mSynap4qEyNlKf9reyxYhDW6r8=",
+        "owner": "holochain",
+        "repo": "holochain",
+        "rev": "a5816b0072a5a1b8c2f8ef215d81728c3d842b1f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "holochain",
+        "ref": "holochain-0.4.1",
+        "repo": "holochain",
+        "type": "github"
+      }
+    },
+    "holonix": {
+      "inputs": {
+        "crane": [
+          "crane"
+        ],
+        "flake-parts": "flake-parts",
+        "hc-launch": "hc-launch",
+        "hc-scaffold": "hc-scaffold",
+        "holochain": "holochain",
+        "lair-keystore": "lair-keystore",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "rust-overlay": [
+          "rust-overlay"
+        ]
+      },
+      "locked": {
+        "lastModified": 1739530473,
+        "narHash": "sha256-ZqWodqoNykg/Fv+XuxJ9UkD0daf7s8OseW/e+X+R4Sk=",
+        "owner": "holochain",
+        "repo": "holonix",
+        "rev": "2572473e1ce1e159af9434e93950bcd9dfb32d29",
+        "type": "github"
+      },
+      "original": {
+        "owner": "holochain",
+        "ref": "main-0.4",
+        "repo": "holonix",
+        "type": "github"
+      }
+    },
+    "lair-keystore": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1683792623,
+        "narHash": "sha256-pQpattmS9VmO3ZIQUFn66az8GSmB4IvYhTTCFn6SUmo=",
+        "owner": "steveej",
+        "repo": "empty",
+        "rev": "8e328e450e4cd32e072eba9e99fe92cf2a1ef5cf",
+        "type": "github"
+      },
+      "original": {
+        "owner": "steveej",
+        "repo": "empty",
         "type": "github"
       }
     },
@@ -338,6 +455,18 @@
         "type": "github"
       }
     },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1735774519,
+        "narHash": "sha256-CewEm1o2eVAnoqb6Ml+Qi9Gg/EfNAxbRx1lANGVyoLI=",
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/e9b51731911566bbf7e4895475a87fe06961de0b.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/e9b51731911566bbf7e4895475a87fe06961de0b.tar.gz"
+      }
+    },
     "nixpkgs-unstable": {
       "locked": {
         "lastModified": 1737885589,
@@ -360,6 +489,7 @@
         "crane": "crane",
         "disko": "disko",
         "extra-container": "extra-container",
+        "holonix": "holonix",
         "nixago": "nixago",
         "nixpkgs": "nixpkgs",
         "nixpkgs-2405": "nixpkgs-2405",

--- a/flake.nix
+++ b/flake.nix
@@ -26,6 +26,15 @@
 
     extra-container.url = "github:erikarvstedt/extra-container";
     extra-container.inputs.nixpkgs.follows = "nixpkgs";
+
+    holonix = {
+      url = "github:holochain/holonix?ref=main-0.4";
+      inputs = {
+        nixpkgs.follows = "nixpkgs";
+        crane.follows = "crane";
+        rust-overlay.follows = "rust-overlay";
+      };
+    };
   };
 
   outputs =

--- a/nix/modules/nixos/holochain/default.nix
+++ b/nix/modules/nixos/holochain/default.nix
@@ -1,0 +1,198 @@
+# Module to configure a holochain service on a nixos machine.
+
+# blueprint specific first level argument that's referred to as "publisherArgs"
+{
+  inputs,
+  ...
+}:
+
+{
+  lib,
+  config,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.holo.holochain;
+in
+{
+  options.holo.holochain = {
+    enable = lib.mkOption {
+      description = "enable holochain";
+      default = true;
+    };
+
+    autoStart = lib.mkOption {
+      default = true;
+    };
+
+    package = lib.mkOption {
+      type = lib.types.package;
+      default = inputs.holonix.packages.${pkgs.system}.holochain;
+    };
+
+    rust = {
+      log = lib.mkOption {
+        type = lib.types.str;
+        default = "debug";
+      };
+
+      backtrace = lib.mkOption {
+        type = lib.types.str;
+        default = "1";
+      };
+    };
+
+    passphraseFile = lib.mkOption {
+      type = lib.types.str;
+      default = "./passphrase.txt";
+    };
+
+    adminWebsocketPort = lib.mkOption {
+      type = lib.types.int;
+      default = 1234;
+    };
+
+    conductorConfig = lib.mkOption {
+      type = lib.types.attrs;
+      default = {
+        data_root_path = "./holochain_data_root";
+
+        # Configure the keystore to be used.
+
+        # Use an in-process keystore with default database location.
+        keystore.type = "lair_server_in_proc";
+
+        # Configure an admin WebSocket interface at a specific port.
+        admin_interfaces = [
+          {
+            driver = {
+              type = "websocket";
+              port = cfg.adminWebsocketPort;
+              allowed_origins = "*";
+            };
+          }
+        ];
+
+        # Configure the network.
+        network = {
+          # Use the Holo-provided default production bootstrap server.
+          bootstrap_service = "https://bootstrap.holo.host";
+
+          # This currently has no effect on functionality but is required. Please just include as-is for now.
+          network_type = "quic_bootstrap";
+
+          # Setup a specific network configuration.
+          transport_pool = [
+            # Use WebRTC, which is the only option for now.
+            {
+
+              type = "webrtc";
+
+              # Use the Holo-provided default production sbd (signal) server.
+              # `signal_url` is REQUIRED.
+              signal_url = "wss://sbd-0.main.infra.holo.host";
+
+              # Override the default WebRTC STUN configuration.
+              # This is OPTIONAL. If this is not specified, it will default
+              # to what you can see here:
+              webrtc_config = {
+                iceServers = [
+                  { urls = [ "stun:stun-0.main.infra.holo.host:443" ]; }
+                  { urls = [ "stun:stun-1.main.infra.holo.host:443" ]; }
+                ];
+              };
+            }
+          ];
+        };
+      };
+    };
+
+    conductorConfigOverrides = lib.mkOption {
+      type = lib.types.attrs;
+      default = { };
+    };
+
+    conductorConfigEffective = lib.mkOption {
+      type = lib.types.attrs;
+      default = lib.attrsets.recursiveUpdate cfg.conductorConfig cfg.conductorConfigOverrides;
+    };
+
+    conductorConfigYaml = lib.mkOption {
+      type = lib.types.path;
+      default = (pkgs.formats.yaml { }).generate "holochain.yml" cfg.conductorConfigEffective;
+    };
+
+    user = lib.mkOption {
+      default = "holochain";
+    };
+    group = lib.mkOption {
+      default = "holochain";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    users.groups.${cfg.group} = { };
+    users.users.${cfg.user} = {
+      isSystemUser = true;
+      inherit (cfg) group;
+    };
+
+    systemd.services.holochain = {
+      enable = true;
+
+      after = [
+        "network.target"
+      ];
+      wants = [
+        "network.target"
+      ];
+      wantedBy = lib.lists.optional cfg.autoStart "multi-user.target";
+
+      restartIfChanged = true;
+
+      environment = {
+        RUST_LOG = "${cfg.rust.log},wasmer_compiler_cranelift=warn";
+        RUST_BACKTRACE = cfg.rust.backtrace;
+      };
+
+      preStart = ''
+        if [[ ! -e "${cfg.passphraseFile}" ]]; then
+          echo generating new passphrase at "${cfg.passphraseFile}".
+          ${lib.getExe pkgs.pwgen} 64 1 > "${cfg.passphraseFile}"
+        else
+          echo using existing passphrase at file ${cfg.passphraseFile}.
+        fi
+      '';
+
+      serviceConfig =
+        let
+          StateDirectory = "holochain";
+        in
+        {
+          User = cfg.user;
+          Group = cfg.user;
+          # %S is short for StateDirectory
+          WorkingDirectory = "%S/${StateDirectory}";
+          inherit StateDirectory;
+          StateDirectoryMode = "0700";
+          Restart = "always";
+          RestartSec = 1;
+          Type = "notify"; # The conductor sends a notify signal to systemd when it is ready
+          NotifyAccess = "all";
+        };
+
+      script = builtins.toString (
+        pkgs.writeShellScript "holochain-wrapper" ''
+          set -xeE
+
+          ${lib.getExe' cfg.package "holochain"} \
+            --piped \
+            --config-path ${cfg.conductorConfigYaml} \
+            < "${cfg.passphraseFile}"
+        ''
+      );
+    };
+  };
+}

--- a/nix/packages/extra-container-holochain.nix
+++ b/nix/packages/extra-container-holochain.nix
@@ -1,0 +1,104 @@
+/*
+  this can be run on a nixos machine (that has extra-containers installed ?) using:
+  $ nix run --refresh github:holo-host/holo-host/extra-container-template-and-holochain#extra-container-holochain -- --restart-changed
+
+  optionally deploy locally to a dev machine:
+
+  $ nix copy --no-check-sigs "$(nix build --print-out-paths .#packages.x86_64-linux.extra-container-holochain)" --to  'ssh-ng://root@towards-allograph.dmz.internal'
+*/
+
+{
+  inputs,
+  system,
+  flake,
+  pkgs,
+  nixpkgs ? inputs.nixpkgs-2411,
+  privateNetwork ? false,
+}:
+
+let
+  adminWebsocketPort = 8000;
+
+  package = inputs.extra-container.lib.buildContainers {
+
+    # The system of the container host
+    inherit system;
+
+    # Optional: Set nixpkgs.
+    # If unset, the nixpkgs input of extra-container flake is used
+    inherit nixpkgs;
+
+    # Only set this if the `system.stateVersion` of your container
+    # host is < 22.05
+    # legacyInstallDirs = true;
+
+    # Set this to disable `nix run` support
+    # addRunner = false;
+
+    config = {
+      containers.holochain = {
+        inherit privateNetwork;
+
+        # `specialArgs` is available in nixpkgs > 22.11
+        # This is useful for importing flakes from modules (see nixpkgs/lib/modules.nix).
+        # specialArgs = { inherit inputs; };
+
+        config =
+          { ... }:
+          {
+            # in case the container shares the host network, don't mess with the firewall rules.
+            networking.firewall.enable = privateNetwork;
+
+            holo.holochain = {
+              inherit adminWebsocketPort;
+            };
+
+            imports = [
+              flake.nixosModules.holochain
+            ];
+          };
+      };
+    };
+
+  };
+  packageWithPlatformFilter = package.overrideAttrs {
+    meta.platforms =
+      with nixpkgs.lib;
+      lists.intersectLists platforms.linux (platforms.x86_64 ++ platforms.aarch64);
+  };
+
+  packageWithPlatformFilterAndTest = packageWithPlatformFilter.overrideAttrs {
+    passthru.tests.integration = pkgs.testers.runNixOSTest (
+      { nodes, lib, ... }:
+      {
+        name = "host-agent-integration-nixos";
+        meta.platforms = lib.lists.intersectLists lib.platforms.linux lib.platforms.x86_64;
+
+        nodes.host =
+          { ... }:
+          {
+            imports = [
+              inputs.extra-container.nixosModules.default
+            ];
+          };
+
+        testScript = _: ''
+          host.start()
+          host.wait_for_unit("multi-user.target")
+          host.succeed("extra-container create ${package}")
+
+          # ensure the port is closed before starting the holochain container
+          host.wait_for_closed_port(${builtins.toString adminWebsocketPort}, timeout = 1)
+
+          host.succeed("extra-container start holochain")
+          host.wait_until_succeeds("systemctl -M holochain is-active holochain", timeout = 60)
+
+          # now the port should be open
+          host.wait_for_open_port(${builtins.toString adminWebsocketPort}, timeout = 1)
+        '';
+      }
+    );
+
+  };
+in
+packageWithPlatformFilterAndTest


### PR DESCRIPTION
this introduces a nixos module for holochain, an extra-container package
with the (almost) default config, and a VM test to ensure the
admin-websocket becomes available on the host.

---

closes https://github.com/Holo-Host/holo-host-private/issues/100

- [x] integration test that demonstrates the admin websocket becomes ready

<details>


```
[root@towards-allograph:~]# /nix/store/7kglpki3ls5f41s0ldgqb8p2v3cyx6qh-container/bin/container create
[root@towards-allograph:~]# /nix/store/7kglpki3ls5f41s0ldgqb8p2v3cyx6qh-container/bin/container start holochain
[root@towards-allograph:~]# machinectl shell holochain /bin/sh -c "PAGER='' systemctl status holochain"
Connected to machine holochain. Press ^] three times within 1s to exit session.
● holochain.service
     Loaded: loaded (/etc/systemd/system/holochain.service; enabled; preset: ignored)
     Active: active (running) since Tue 2025-02-18 20:35:22 UTC; 1min 4s ago
 Invocation: b6647b92dfe54f90878bcbc080131e7f
    Process: 298 ExecStartPre=/nix/store/i8b3wl9vnn1cfm8ij9mkihn2p29ibkpv-unit-script-holochain-pre-start/bin/holochain-pre-start (code=exited, status=0/SUCCESS)
   Main PID: 312 (holochain-start)
         IO: 0B read, 424K written
      Tasks: 26 (limit: 19061)
     Memory: 10.1M (peak: 266.8M)
        CPU: 2.260s
     CGroup: /system.slice/holochain.service
             ├─312 /nix/store/gwgqdl0242ymlikq9s9s62gkp5cvyal3-bash-5.2p37/bin/bash /nix/store/mb0inbiq9hdc0fjdfxird0kxk8l5jwr4-unit-script-holochain-start/b…
             ├─315 /nix/store/gwgqdl0242ymlikq9s9s62gkp5cvyal3-bash-5.2p37/bin/bash /nix/store/xvfv7xvbdl9njz8q3ay579k323pw9ixs-holochain-wrapper
             └─316 /nix/store/223i4mrvfjjqp7h280fqmq7fwyf2mzzi-holochain-0.4.1/bin/holochain --piped --config-path /nix/store/zqdnp074hkkqvmx105hmr2fjmvzwnra…

Feb 18 20:35:22 holochain holochain-start[316]: ###HOLOCHAIN_SETUP###
Feb 18 20:35:22 holochain holochain-start[316]: ###ADMIN_PORT:1234###
Feb 18 20:35:22 holochain holochain-start[316]: ###HOLOCHAIN_SETUP_END###
Feb 18 20:35:22 holochain holochain-start[316]: 2025-02-18T20:35:22.619323Z  INFO holochain: crates/holochain/src/bin/holochain/main.rs:105: Condu…nitialized.
Feb 18 20:35:22 holochain holochain-start[316]: Conductor ready.
Feb 18 20:35:22 holochain systemd[1]: Started holochain.service.
Feb 18 20:35:34 holochain holochain-start[316]: 2025-02-18T20:35:34.054502Z  INFO kitsune-metric-task: kitsune_p2p_types::metrics: crates/kitsune_p2p/types/s…
Feb 18 20:35:49 holochain holochain-start[316]: 2025-02-18T20:35:49.096513Z  INFO kitsune-metric-task: kitsune_p2p_types::metrics: crates/kitsune_p2p/types/s…
Feb 18 20:36:04 holochain holochain-start[316]: 2025-02-18T20:36:04.141015Z  INFO kitsune-metric-task: kitsune_p2p_types::metrics: crates/kitsune_p2p/types/s…
Feb 18 20:36:19 holochain holochain-start[316]: 2025-02-18T20:36:19.185992Z  INFO kitsune-metric-task: kitsune_p2p_types::metrics: crates/kitsune_p2p/types/s…
Hint: Some lines were ellipsized, use -l to show in full.
Connection to machine holochain terminated.
```

</details>