### PR TITLE
feat(gh/workflows/enforce-branch-name): provide exception label

### DIFF
--- a/.github/workflows/enforce-branch-name.yml
+++ b/.github/workflows/enforce-branch-name.yml
@@ -13,6 +13,7 @@ on:
 jobs:
   validate-branch-name:
     runs-on: ubuntu-latest
+    if: ${{ ! contains(github.event.pull_request.labels.*.name, 'ci/skip-enforce-naming') }}
     steps:
       - name: Check Branch Name
         run: |


### PR DESCRIPTION
every now and then we make ad-hoc changes that justify a separate PR. enforcing to backfill a ticket for every case seems too much of a burocratic burden to me. by adding a label we make exceptions explicit, and the PR will still be subject to the review policy. if the PR description gives sufficient context and rationale for the PR it's enough to inform the reviewers.