### PR TITLE
chore: suppress mongodb test instance std{err,out}

### DIFF
--- a/rust/util_libs/src/db/mongodb.rs
+++ b/rust/util_libs/src/db/mongodb.rs
@@ -222,7 +222,7 @@ mod tests {
     /// This module implements running ephemeral Mongod instances.
     /// It disables TCP and relies only unix domain sockets.
     mod mongo_runner {
-        use std::{path::PathBuf, str::FromStr};
+        use std::{path::PathBuf, process::Stdio, str::FromStr};
 
         use anyhow::Context;
         use mongodb::{options::ClientOptions, Client};
@@ -263,7 +263,9 @@ mod tests {
                     &Self::socket_path(&tempdir)?,
                     "--port",
                     &0.to_string(),
-                ]);
+                ])
+                .stdout(Stdio::null())
+                .stderr(Stdio::null());
 
                 let child = cmd
                     .spawn()


### PR DESCRIPTION
output example:

```
{"t":{"$date":"2025-02-20T15:21:17.131-08:00"},"s":"E",  "c":"WT",       "id":22435,   "ctx":"thread29","msg":"WiredTiger error message","attr":{"error":2,"message":{"ts_sec":1740093677,"ts_usec":131049,"thread":"1143582:0x7fdff44006c0","session_name":"log-server","category":"WT_VERB_DEFAULT","category_id":9,"verbose_level":"ERROR","verbose_level_id":-3,"msg":"__directory_list_worker:46:/tmp/.tmpC4Zbdt/journal: directory-list: opendir","error_str":"No such file or directory","error_code":2}}}
{"t":{"$date":"2025-02-20T15:21:17.131-08:00"},"s":"E",  "c":"WT",       "id":22435,   "ctx":"thread29","msg":"WiredTiger error message","attr":{"error":2,"message":{"ts_sec":1740093677,"ts_usec":131253,"thread":"1143582:0x7fdff44006c0","session_name":"log-server","category":"WT_VERB_DEFAULT","category_id":9,"verbose_level":"ERROR","verbose_level_id":-3,"msg":"__log_prealloc_once:514:log pre-alloc server error","error_str":"No such file or directory","error_code":2}}}
{"t":{"$date":"2025-02-20T15:21:17.131-08:00"},"s":"E",  "c":"WT",       "id":22435,   "ctx":"thread29","msg":"WiredTiger error message","attr":{"error":2,"message":{"ts_sec":1740093677,"ts_usec":131302,"thread":"1143582:0x7fdff44006c0","session_name":"log-server","category":"WT_VERB_DEFAULT","category_id":9,"verbose_level":"ERROR","verbose_level_id":-3,"msg":"__log_server:924:log server error","error_str":"No such file or directory","error_code":2}}}
```