### PR TITLE
tests(cargo-nextest): configure retries and slow-timeout

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,5 @@
+# see https://nexte.st/docs/configuration/?h=config for a reference
+
+[profile.default]
+retries = { backoff = "exponential", count = 5, delay = "1s", jitter = true }
+slow-timeout = { period = "60s", terminate-after = 2 }


### PR DESCRIPTION
the primary motivation for this is having seen a test being reported SLOW for over 3 days without termination.

for the "retries", we haven't seen any flaky tests (yet), however putting in these defaults that i experienced helpful in other projects.