### PR TITLE
Holochain container networked zome calls test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,4 +25,4 @@ leaf_server.conf
 rust/*/*/*/tmp/
 rust/*/*/*/*/tmp/
 
-ham.state
+ham.state*

--- a/Justfile
+++ b/Justfile
@@ -1,35 +1,45 @@
 state-file := "./ham.state"
 
-# dev cycle for testing ham with a fresh container
-ham-test:
+help:
+    just --list
+
+holochain-container i:
     #!/usr/bin/env bash
     set -xeE
-    result=$(nix build --no-link --print-out-paths .#extra-container-holochain)
+    result=$(nix build --no-link --print-out-paths --impure --expr "(builtins.getFlake \"git+file://${PWD}\").packages.\${builtins.currentSystem}.extra-container-holochain.override { index = {{i}}; }")
     "$result"/bin/container destroy
     # no need to keep it around if lair is destroyed with the container
-    rm {{state-file}} || :
+    rm {{state-file}}.{{ i }} || :
     "$result"/bin/container create
-    "$result"/bin/container start holochain
 
-    while ! sudo systemctl -M holochain is-active holochain; do
+    "$result"/bin/container start "holochain{{ i }}"
+    while ! sudo systemctl -M "holochain{{ i }}" is-active holochain; do
         sleep 1
     done
 
+holochain-container-destroy i:
+    extra-container destroy holochain{{ i }}
+
+ham i +args:
     cargo run --bin ham -- \
-        --port 8000 \
-        --state-path {{state-file}} \
-        install-and-init-happ \
-                --happ $(nix build --no-link --print-out-paths -vL .\#holochain-zome-testing-happ)/happ.bundle \
-                --network-seed "ham-test"
+        --port "$((8000 + {{i}} ))" \
+        --state-path {{state-file}}."{{i}}" \
+        {{ args }}
+
+ham-install i:
+    just ham {{i}} install-and-init-happ \
+        --happ $(nix build --no-link --print-out-paths -vL .\#holochain-zome-testing-happ)/happ.bundle \
+        --network-seed "ham-test"
 
 # make zomecalls to a holochain instance that was set up with `ham-test`
-ham-test-zomecalls zomecalls="holochain_zome_testing_0:roundtrip:'hello zome world'":
+ham-zomecalls i zomecalls="holochain_zome_testing_0:get_registrations_pretty":
+    just ham {{i}} zome-calls \
+        --zome-calls "{{zomecalls}}"
+
+# this will ensure a new holochain container at index i, and install the test zomes in it
+ham-cycle i:
     #!/usr/bin/env bash
     set -xeE
-    cargo run --bin ham -- \
-        --port 8000 \
-        --state-path {{state-file}} \
-        zome-calls \
-            --zome-calls "{{zomecalls}}"
-
-ham: ham-test ham-test-zomecalls
+    just holochain-container-destroy {{i}}
+    just holochain-container {{i}}
+    just ham-install {{i}}

--- a/nix/modules/nixos/holochain/default.nix
+++ b/nix/modules/nixos/holochain/default.nix
@@ -44,6 +44,12 @@ in
       };
     };
 
+    wasmLog = lib.mkOption {
+      type = lib.types.str;
+      default = "info";
+      description = "configure wasm log level (zomes)";
+    };
+
     passphraseFile = lib.mkOption {
       type = lib.types.str;
       default = "./passphrase.txt";
@@ -155,6 +161,7 @@ in
       environment = {
         RUST_LOG = "${cfg.rust.log},wasmer_compiler_cranelift=warn";
         RUST_BACKTRACE = cfg.rust.backtrace;
+        WASM_LOG = cfg.wasmLog;
       };
 
       preStart = ''

--- a/nix/packages/extra-container-holochain.nix
+++ b/nix/packages/extra-container-holochain.nix
@@ -14,10 +14,12 @@
   pkgs,
   nixpkgs ? inputs.nixpkgs-2411,
   privateNetwork ? false,
+  index ? 0,
+  adminWebsocketPort ? 8000 + index,
+  containerName ? "holochain${builtins.toString index}",
 }:
 
 let
-  adminWebsocketPort = 8000;
 
   package = inputs.extra-container.lib.buildContainers {
 
@@ -36,7 +38,7 @@ let
     # addRunner = false;
 
     config = {
-      containers.holochain = {
+      containers."${containerName}" = {
         inherit privateNetwork;
 
         # `specialArgs` is available in nixpkgs > 22.11
@@ -90,8 +92,8 @@ let
           # ensure the port is closed before starting the holochain container
           host.wait_for_closed_port(${builtins.toString adminWebsocketPort}, timeout = 1)
 
-          host.succeed("extra-container start holochain")
-          host.wait_until_succeeds("systemctl -M holochain is-active holochain", timeout = 60)
+          host.succeed("extra-container start ${containerName}")
+          host.wait_until_succeeds("systemctl -M ${containerName} is-active holochain", timeout = 60)
 
           # now the port should be open
           host.wait_for_open_port(${builtins.toString adminWebsocketPort}, timeout = 1)

--- a/rust/ham/src/main.rs
+++ b/rust/ham/src/main.rs
@@ -173,15 +173,6 @@ async fn main() -> Result<()> {
                         .authorize_signing_credentials(AuthorizeSigningCredentialsPayload {
                             cell_id: cell_id.clone(),
                             functions: Some(GrantedFunctions::All),
-                            // functions: Some(GrantedFunctions::Listed(
-                            //     [(
-                            //         install_and_init_happ_cmd_args.zome_name.clone(),
-                            //         install_and_init_happ_cmd_args.zome_fn_name.clone(),
-                            //     )]
-                            //     .into_iter()
-                            //     .map(|(zn, funcname)| (zn.into(), funcname.into()))
-                            //     .collect::<BTreeSet<(ZomeName, FunctionName)>>(),
-                            // )),
                         })
                         .await
                         .context(format!(
@@ -189,13 +180,6 @@ async fn main() -> Result<()> {
                             &cell_id,
                         ))?;
                     signer.add_credentials(cell_id.clone(), credentials);
-
-                    // let all_functions = app_ws
-                    //     .list_wasm_host_functions()
-                    //     .await?
-                    //     .into_iter()
-                    //     .collect::<BTreeSet<_>>();
-                    // println!("all functions: {all_functions:#?}");
 
                     'given_zome_calls: for (zome_name, (zome_fn_name, maybe_zome_fn_payload)) in
                         zome_calls_args.zome_calls.iter()
@@ -234,16 +218,11 @@ async fn main() -> Result<()> {
                                 payload,
                             )
                             .await
+                            .map(|io| -> Result<Vec<String>, _> { io.decode() })
                         {
-                            Ok(io) => {
-                                let response: Result<String, _> = io.decode();
-                                println!(
-                                    "success. got response with {} bytes:\n{response:#?}",
-                                    io.as_bytes().len()
-                                )
-                            }
-
-                            Err(e) => eprintln!("error: {e}",),
+                            Ok(Ok(data)) => println!("success, got data:\n{data:#?}"),
+                            Ok(Err(e)) => eprintln!("error: {e}"),
+                            Err(e) => eprintln!("error: {e}"),
                         };
                     }
                 }

--- a/rust/holochain_zome_testing_0/src/lib.rs
+++ b/rust/holochain_zome_testing_0/src/lib.rs
@@ -1,10 +1,48 @@
 // use the re-exports from the integrity zome to ensure same versions
 // use holochain_zome_testing_0_integrity::hdi;
-use holochain_zome_testing_0_integrity::hdk;
+use holochain_zome_testing_0_integrity::{
+    get_participant_registration_anchor_hash, hdk, types::LinkTypes,
+};
 
 use hdk::prelude::*;
 
 #[hdk_extern]
-fn roundtrip(input: String) -> Result<String, WasmError> {
-    Ok(format!("roundtripping {input}"))
+pub fn init() -> ExternResult<InitCallbackResult> {
+    let participant_registration_anchor_hash = get_participant_registration_anchor_hash()?;
+    let AgentInfo {
+        agent_latest_pubkey: my_pubkey,
+        ..
+    } = agent_info()?;
+
+    create_link(
+        participant_registration_anchor_hash,
+        my_pubkey,
+        LinkTypes::ParticipantRegistration,
+        (),
+    )?;
+
+    Ok(InitCallbackResult::Pass)
+}
+
+#[hdk_extern]
+pub fn get_registrations_pretty(_: ()) -> ExternResult<Vec<String>> {
+    hdk::prelude::info!("get_registrations called info");
+    hdk::prelude::debug!("get_registrations called debug");
+
+    let participant_registration_anchor_hash = get_participant_registration_anchor_hash()?;
+
+    let registrations = get_links(
+        GetLinksInputBuilder::try_new(
+            participant_registration_anchor_hash,
+            LinkTypes::ParticipantRegistration,
+        )?
+        .build(),
+    )?;
+
+    let registrations_pretty = registrations
+        .into_iter()
+        .map(|link| format!("{link:#?}"))
+        .collect();
+
+    Ok(registrations_pretty)
 }

--- a/rust/holochain_zome_testing_0_integrity/src/lib.rs
+++ b/rust/holochain_zome_testing_0_integrity/src/lib.rs
@@ -14,3 +14,16 @@ fn validate(op: Op) -> ExternResult<ValidateCallbackResult> {
 
     Ok(ValidateCallbackResult::Valid)
 }
+
+pub mod types {
+    use hdi::prelude::*;
+
+    #[hdk_link_types]
+    pub enum LinkTypes {
+        ParticipantRegistration,
+    }
+}
+
+pub fn get_participant_registration_anchor_hash() -> ExternResult<EntryHash> {
+    Path(vec!["_participants_".into()]).path_entry_hash()
+}


### PR DESCRIPTION
- [x] builds on top of #90 

part of https://github.com/Holo-Host/holo-host-private/issues/127

---

demonstrates cross-container holochain traffic.

note that it's somewhat bogus because currently the containers share a common network namespace (with the host).

the following commands are enough to demonstrate the functionality here:

```
just ham-cycle 0
just ham-cycle 1

# now there will be two containers that run holochain inside with the test happ installed


# the following commands can be used repeatedly until both display the same result. this relies on the holochain gossip and can take a bit as we're using publicly available bootstrap/signal servers in this test
just ham-zomecalls 0 holochain_zome_testing_0:get_registrations_pretty
just ham-zomecalls 1 holochain_zome_testing_0:get_registrations_pretty
```
