### PR TITLE
fix(rust/types/WorkloadServiceSubjects): use snake_case for AsRefStr

### DIFF
--- a/rust/services/workload/src/types.rs
+++ b/rust/services/workload/src/types.rs
@@ -12,6 +12,7 @@ pub struct ObjectIdJSON {
 
 #[derive(Serialize, Deserialize, Clone, Debug, AsRefStr)]
 #[serde(rename_all = "snake_case")]
+#[strum(serialize_all = "snake_case")]
 pub enum WorkloadServiceSubjects {
     Add,
     Update,


### PR DESCRIPTION
this aligns strum's naming with serde's naming.
this will cause WORKLOAD topic subjects to use the snake_case naming. i.e. `WORKLOAD.{pubkey}.Install` becomes `WORKLOAD.{pubkey}.install`.

