### PR TITLE
chore: use rust-toolchain rust-analyzer, tolerate clippy warnings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -17,7 +17,12 @@
   },
   "rust-analyzer.check.command": "clippy",
   "rust-analyzer.check.allTargets": true,
-  "rust-analyzer.check.extraArgs": ["--", "--deny=warnings"],
+  "rust-analyzer.check.extraArgs": [
+    "--",
+    "--no-deps"
+    // unfortunately this causes clippy to stop on the first occurrence of a warning, so actual compiler errors are obfuscated
+    // "--deny=warnings"
+  ],
   "[rust]": {
     "editor.defaultFormatter": "rust-lang.rust-analyzer"
   },

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,13 @@
 [toolchain]
 channel = "1.85.0"
-components = ["cargo", "llvm-tools", "rustc", "clippy", "rust-src", "rustfmt"]
+components = [
+  "rust-analyzer",
+  "cargo",
+  "llvm-tools",
+  "rustc",
+  "clippy",
+  "rust-src",
+  "rustfmt",
+]
 targets = ["wasm32-unknown-unknown"]
 profile = "minimal"


### PR DESCRIPTION
extracted from #100 