### PR TITLE
fix(hpos-agent/inventory): startup behavior and resiliency

### DIFF
--- a/rust/clients/host_agent/src/hostd/inventory.rs
+++ b/rust/clients/host_agent/src/hostd/inventory.rs
@@ -9,7 +9,9 @@
   This client does not subject to or consume any inventory subjects.
 */
 
-use anyhow::Result;
+use std::{path::Path, time::Duration};
+
+use futures::TryFutureExt;
 use hpos_hal::inventory::HoloInventory;
 use inventory::INVENTORY_UPDATE_SUBJECT;
 use nats_utils::{
@@ -26,30 +28,29 @@ pub fn should_check_inventory(
     now.signed_duration_since(start) > check_interval_duration
 }
 
+/// Periodically checks for inventory changes and publishes them on a NATS subject.
+/// Never returns.
 pub async fn run(
     host_client: JsClient,
     host_id: &str,
-    inventory_file_path: &str,
+    inventory_file_path_str: &str,
     host_inventory_check_interval_sec: u64,
-    starting_inventory: HoloInventory,
-) -> Result<(), ServiceError> {
+) -> ! {
     log::info!("Host Agent Client: starting Inventory job...");
-
-    // Store latest inventory record in memory
-    starting_inventory
-        .save_to_file(inventory_file_path)
-        .map_err(|e| {
-            ServiceError::internal(
-                e.to_string(),
-                Some("Failed to save host inventory to file.".to_string()),
-            )
-        })?;
 
     let one_hour_interval = tokio::time::Duration::from_secs(host_inventory_check_interval_sec);
     let check_interval_duration = chrono::TimeDelta::seconds(one_hour_interval.as_secs() as i64);
-    let mut last_check_time = chrono::Utc::now();
+    let mut last_check_time = chrono::Utc::now() - one_hour_interval;
 
     let pubkey_lowercase = host_id.to_lowercase();
+
+    let inventory_file_path = Path::new(inventory_file_path_str);
+
+    // used in case of an error when reading/parsing the persisted inventory
+    let retry_in_default = std::time::Duration::from_secs(10);
+    let mut retry_in = retry_in_default;
+    let bump_retry_in =
+        |ref mut retry_in| *retry_in = std::cmp::min(*retry_in * 2, Duration::from_secs(1800));
 
     loop {
         // Periodically check inventory and compare against latest state (in-memory)
@@ -57,44 +58,76 @@ pub async fn run(
             log::debug!("Checking Host inventory...");
 
             let current_inventory = HoloInventory::from_host();
-            if HoloInventory::load_from_file(inventory_file_path).map_err(|e| {
-                ServiceError::internal(
-                    e.to_string(),
-                    Some("Failed to read host inventory from file.".to_string()),
-                )
-            })? != current_inventory
-            {
-                log::debug!("Host Inventory has changed.  About to push update to Orchestrator");
-                let authenticated_user_inventory_subject =
-                    format!("INVENTORY.{pubkey_lowercase}.{INVENTORY_UPDATE_SUBJECT}");
-
-                let payload_bytes = serde_json::to_vec(&current_inventory)?;
-
-                let payload = PublishInfo {
-                    subject: authenticated_user_inventory_subject,
-                    msg_id: chrono::Utc::now().to_string(),
-                    data: payload_bytes,
-                    headers: None,
-                };
-
-                host_client.publish(payload).await.map_err(|e| {
-                    ServiceError::nats(
-                        e.to_string(),
-                        Some("Failed to publish host inventory.".to_string()),
+            match inventory_file_path
+                // check if the file exists
+                .metadata()
+                .map_err(hpos_hal::inventory::InventoryError::from)
+                // on success try to parse it as an inventory
+                .and_then(|_| HoloInventory::load_from_file(inventory_file_path_str))
+                // log errors if it couldn't be read or parsed, and continue to publish the current one and persist it
+                .inspect_err(|e| {
+                    log::error!(
+                        "Failed to read host inventory from file at {inventory_file_path_str}: {e}"
                     )
-                })?;
-                current_inventory
-                    .save_to_file(inventory_file_path)
-                    .map_err(|e| {
-                        ServiceError::internal(
+                })
+                .map(|loaded_inventory| loaded_inventory == current_inventory)
+            {
+                Ok(true) => {
+                    log::debug!("Host Inventory has not changed.");
+                }
+
+                Ok(false) | Err(_) => {
+                    log::debug!(
+                        "Host Inventory has changed or could not be loaded from {inventory_file_path_str}.  About to push update to Orchestrator"
+                    );
+                    let authenticated_user_inventory_subject =
+                        format!("INVENTORY.{pubkey_lowercase}.{INVENTORY_UPDATE_SUBJECT}");
+
+                    let payload = async {
+                        serde_json::to_vec(&current_inventory).map_err(anyhow::Error::from)
+                    }
+                    .and_then(|payload_bytes| async {
+                        Ok(PublishInfo {
+                            subject: authenticated_user_inventory_subject.clone(),
+                            msg_id: chrono::Utc::now().to_string(),
+                            data: payload_bytes,
+                            headers: None,
+                        })
+                    })
+                    .and_then(|payload| host_client.publish(payload).map_err(anyhow::Error::from));
+
+                    if let Err(e) = payload.await.map_err(|e| {
+                        ServiceError::nats(
                             e.to_string(),
-                            Some("Failed to save host inventory to file.".to_string()),
+                            Some("Failed to publish host inventory.".to_string()),
                         )
-                    })?;
-            } else {
-                log::debug!("Host Inventory has not changed.");
+                    }) {
+                        log::error!("error publishing latest inventory on {authenticated_user_inventory_subject}: {e}\n. will retry in {retry_in:#?}");
+                        sleep(retry_in).await;
+                        bump_retry_in(retry_in);
+                        continue;
+                    };
+                    if let Err(e) =
+                        current_inventory
+                            .save_to_file(inventory_file_path_str)
+                            .map_err(|e| {
+                                ServiceError::internal(
+                                    e.to_string(),
+                                    Some(format!(
+                                    "Failed to save host inventory to file {inventory_file_path_str}"
+                                )),
+                                )
+                            })
+                    {
+                        log::error!("{e}. will retry in {retry_in:#?}");
+                        sleep(retry_in).await;
+                        bump_retry_in(retry_in);
+                        continue;
+                    };
+                }
             }
 
+            retry_in = retry_in_default;
             last_check_time = chrono::Utc::now();
         }
 

--- a/rust/clients/host_agent/src/main.rs
+++ b/rust/clients/host_agent/src/main.rs
@@ -87,17 +87,13 @@ async fn daemonize(args: &DaemonzeArgs) -> Result<(), async_nats::Error> {
     let host_id_inventory_clone = host_id.clone();
     let inventory_interval = host_inventory_check_interval_sec.to_owned();
     spawn(async move {
-        if let Err(e) = hostd::inventory::run(
+        hostd::inventory::run(
             host_client_inventory_clone,
             &host_id_inventory_clone,
             &inventory_file_path,
             inventory_interval,
-            host_inventory,
         )
         .await
-        {
-            log::error!("Error running host agent workload service. Err={:?}", e)
-        };
     });
 
     let host_client_workload_clone = host_client.clone();


### PR DESCRIPTION
startup behavior: starting at `now` it would previously wait an entire interval before sending the inventory; solely based on the time check.

resiliency: never stop trying to send inventory messages. back off the time between attempts and reset the retry on every successful event.

---

i discovered the issues while working on #100.

alternative and preferred alternative to #120. therefore:

closes #120.
