### PR TITLE
feat(host_agent): introduce and test `remote` subcommand with NATS ping

### DIFF
--- a/nix/packages/rust-workspace.nix
+++ b/nix/packages/rust-workspace.nix
@@ -113,6 +113,7 @@ craneLib.buildPackage (
               pname = "host_agent";
               cargoExtraArgs = "-p host_agent";
               cargoArtifacts = mkCargoArtifacts src;
+              meta.mainProgram = "host_agent";
             }
           );
 

--- a/rust/clients/host_agent/src/agent_cli.rs
+++ b/rust/clients/host_agent/src/agent_cli.rs
@@ -1,5 +1,5 @@
 use clap::{Args, Parser, Subcommand};
-use nats_utils::leaf_server::LEAF_SERVER_DEFAULT_LISTEN_PORT;
+use nats_utils::{leaf_server::LEAF_SERVER_DEFAULT_LISTEN_PORT, types::NatsRemoteArgs};
 use netdiag::IPVersion;
 use std::path::PathBuf;
 
@@ -32,6 +32,21 @@ pub enum CommandScopes {
         #[command(subcommand)]
         command: SupportCommands,
     },
+
+    /// Interact with a remote host-agent (via NATS).
+    Remote {
+        #[clap(flatten)]
+        remote_args: RemoteArgs,
+
+        #[command(subcommand)]
+        command: RemoteCommands,
+    },
+}
+
+#[derive(Clone, clap::Parser)]
+pub struct RemoteArgs {
+    #[clap(flatten)]
+    pub nats_remote_args: NatsRemoteArgs,
 }
 
 #[derive(Args, Clone, Debug)]
@@ -85,13 +100,6 @@ pub struct DaemonzeArgs {
 
     #[arg(
         long,
-        help = "disable host agent inventory functionality",
-        default_value_t = false
-    )]
-    pub(crate) host_inventory_disable: bool,
-
-    #[arg(
-        long,
         env = "NATS_LEAF_SERVER_LISTEN_HOST",
         default_value = "127.0.0.1",
         value_parser = |s: &str| url::Host::<String>::parse(s),
@@ -142,4 +150,11 @@ pub enum SupportCommands {
         #[arg(long)]
         enable: bool,
     },
+}
+
+/// A set of commands for remotely interacting with a running host-agent instance, by exchanging NATS messages.
+#[derive(Subcommand, Clone)]
+pub enum RemoteCommands {
+    /// Status
+    Ping {},
 }

--- a/rust/clients/host_agent/src/remote_cmds/mod.rs
+++ b/rust/clients/host_agent/src/remote_cmds/mod.rs
@@ -1,0 +1,29 @@
+use nats_utils::{jetstream_client::JsClient, types::JsClientBuilder};
+
+use crate::agent_cli::{self, RemoteArgs, RemoteCommands};
+
+pub(crate) async fn run(args: RemoteArgs, command: RemoteCommands) -> anyhow::Result<()> {
+    let nats_client = {
+        let nats_url = args.nats_remote_args.nats_url.clone();
+        JsClient::new(JsClientBuilder {
+            nats_remote_args: args.nats_remote_args,
+
+            ..Default::default()
+        })
+        .await
+        .map_err(|e| anyhow::anyhow!("connecting to NATS via {nats_url:?}: {e:?}"))
+    }?;
+
+    match command {
+        agent_cli::RemoteCommands::Ping {} => {
+            let check = nats_client
+                .check_connection()
+                .await
+                .map_err(|e| anyhow::anyhow!(e.to_string()))?;
+
+            log::info!("Connection check result: {check}");
+        }
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
this modifies the host-agent nixos integration test to perform a NATS connectivity check using the introduced `remote ping` subcommand.

extracted from #100.
