### PR TITLE
feat(util_libs): tolerate anyhow errors, host/workload schema schemas

### DIFF
--- a/rust/services/inventory/src/tests/inventory_api.rs
+++ b/rust/services/inventory/src/tests/inventory_api.rs
@@ -1,4 +1,3 @@
-#[cfg(not(target_arch = "aarch64"))]
 #[cfg(test)]
 mod tests {
     use crate::InventoryServiceApi;

--- a/rust/services/workload/src/orchestrator_api.rs
+++ b/rust/services/workload/src/orchestrator_api.rs
@@ -258,7 +258,7 @@ impl OrchestratorWorkloadApi {
                         )
                     })?;
 
-                // Create tag map with host ids to inform nats to publish message to these hosts with workload install status                
+                // Create tag map with host ids to inform nats to publish message to these hosts with workload install status
                 let mut tag_map: HashMap<String, String> = HashMap::new();
                 for (index, host_id) in assigned_host_ids.iter().cloned().enumerate() {
                     let assigned_host = eligible_hosts.iter().find(|h| h._id == host_id).ok_or_else(|| ServiceError::internal("Error: Failed to locate host device id from assigned host ids.".to_string(), Some("Unable to forward workload to Host.".to_string())))?;

--- a/rust/services/workload/src/tests/orchestrator_api.rs
+++ b/rust/services/workload/src/tests/orchestrator_api.rs
@@ -1,4 +1,3 @@
-#[cfg(not(target_arch = "aarch64"))]
 #[cfg(test)]
 mod tests {
     use crate::{orchestrator_api::OrchestratorWorkloadApi, types::WorkloadResult};

--- a/rust/services/workload/src/tests/orchestrator_api.rs
+++ b/rust/services/workload/src/tests/orchestrator_api.rs
@@ -144,8 +144,9 @@ mod tests {
             Some(required_avg_network_speed),
             Some(required_avg_uptime),
         );
+        let device_id = "host_inventory_machine_id_1";
         let host = create_test_host(
-            None,
+            device_id,
             None,
             None,
             Some(valid_host_remaining_capacity),
@@ -201,8 +202,9 @@ mod tests {
         valid_host_remaining_capacity.cpus = gen_mock_processors(20);
 
         // Create and add a host first
+        let device_id = "host_inventory_machine_id_2";
         let host = create_test_host(
-            None,
+            device_id,
             None,
             None,
             Some(valid_host_remaining_capacity),

--- a/rust/util_libs/db/src/tests/mod.rs
+++ b/rust/util_libs/db/src/tests/mod.rs
@@ -1,2 +1,1 @@
-#[cfg(not(target_arch = "aarch64"))]
 pub mod mongodb;

--- a/rust/util_libs/db/src/tests/mongodb.rs
+++ b/rust/util_libs/db/src/tests/mongodb.rs
@@ -36,7 +36,6 @@ async fn test_indexing_and_api() -> Result<()> {
                 deleted_at: None,
             },
             device_id: "placeholder_pubkey_host".to_string(),
-            ip_address: "127.0.0.1".to_string(),
             inventory: HoloInventory {
                 ..Default::default()
             },
@@ -44,7 +43,7 @@ async fn test_indexing_and_api() -> Result<()> {
             avg_network_speed: 500,
             avg_latency: 10,
             assigned_workloads: vec![oid::ObjectId::new()],
-            assigned_hoster: oid::ObjectId::new(),
+            assigned_hoster: Some(oid::ObjectId::new()),
         }
     }
 

--- a/rust/util_libs/mocks/src/host.rs
+++ b/rust/util_libs/mocks/src/host.rs
@@ -38,19 +38,20 @@ pub fn create_mock_inventory(
 
 // Helper function to create a test host
 pub fn create_test_host(
-    device_id: Option<String>,
+    device_id: &str,
     assigned_hoster: Option<ObjectId>,
     assigned_workloads: Option<Vec<ObjectId>>,
     holo_inventory: Option<HoloInventory>,
     avg_network_speed: Option<i64>,
     avg_uptime: Option<f64>,
 ) -> schemas::Host {
-    let mut host = schemas::Host::default();
-    if let Some(device_id) = device_id {
-        host.device_id = device_id;
-    }
+    let mut host = schemas::Host {
+        device_id: device_id.to_string(),
+        ..Default::default()
+    };
+
     if let Some(assigned_hoster) = assigned_hoster {
-        host.assigned_hoster = assigned_hoster;
+        host.assigned_hoster = Some(assigned_hoster);
     }
     if let Some(assigned_workloads) = assigned_workloads {
         host.assigned_workloads = assigned_workloads;

--- a/rust/util_libs/nats/src/macros.rs
+++ b/rust/util_libs/nats/src/macros.rs
@@ -1,10 +1,28 @@
+// TODO(refactor): this is very unclear in case of an error, e.g. the $method_name doesn't exist on the API
 #[macro_export]
 macro_rules! generate_service_call {
     ($api:expr, $method_name:ident) => {{
         let api = $api.clone();
         std::sync::Arc::new(move |msg: std::sync::Arc<async_nats::Message>| {
             let api_clone = api.clone();
-            Box::pin(async move { api_clone.$method_name(msg).await })
+            Box::pin(async move {
+                use nats_utils::types::ServiceError;
+                api_clone
+                    .$method_name(msg)
+                    .await
+                    .map_err(|e| -> ServiceError {
+                        log::error!("{e}");
+                        let a = anyhow::Error::from(e);
+                        log::error!("{a}");
+                        match a.downcast::<ServiceError>() {
+                            Ok(se) => se.clone(),
+                            Err(e) => ServiceError::Internal {
+                                message: e.to_string(),
+                                context: None,
+                            },
+                        }
+                    })
+            })
         })
     }};
 }


### PR DESCRIPTION
* the macro now tolerates results that declare anyhow::Error for NATS
  consumer functions
* host and workload schema changes



extracted from #100 