### PR TITLE
176: Add NS RR support to DNS server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1445,9 +1445,8 @@ dependencies = [
 
 [[package]]
 name = "dns-server"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaeda8a7efcfb0ff123fcad959beaec55aa6d1be1d535f54b5b8b873f3cf1680"
+version = "0.2.5"
+source = "git+https://gitlab.com/matt.geddes/ops.git?branch=add-in-ns-rr#859924ebe6f989278d8a7b979574c9132cf8b100"
 dependencies = [
  "fixed-buffer",
  "oorandom",
@@ -4654,8 +4653,7 @@ dependencies = [
 [[package]]
 name = "prob-rate-limiter"
 version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22624ab4acf3a452d4452a1eb5efbdc9d2dbb18bdcafce67fcd59b3f7ecf6238"
+source = "git+https://gitlab.com/matt.geddes/ops.git?branch=add-in-ns-rr#859924ebe6f989278d8a7b979574c9132cf8b100"
 dependencies = [
  "oorandom",
 ]

--- a/rust/holo-dns/Cargo.toml
+++ b/rust/holo-dns/Cargo.toml
@@ -9,7 +9,11 @@ path = "bin/holo-dns.rs"
 
 
 [dependencies]
-dns-server = "0.2.4"
+# I have an open merge request with the upstream package maintainer for the NS record changes.
+# Once merged and a new crate is published, we ought to be able to use crate v0.2.5 instead of
+# the gitlab link below.
+#dns-server = "0.2.4"
+dns-server = { git = "https://gitlab.com/matt.geddes/ops.git", branch = "add-in-ns-rr" }
 env_logger = { workspace = true }
 log = { workspace = true }
 permit = "0.2.1"

--- a/rust/holo-dns/src/dns_service.rs
+++ b/rust/holo-dns/src/dns_service.rs
@@ -1,4 +1,4 @@
-use dns_server::{DnsClass, DnsQuestion, DnsRecord, DnsType};
+use dns_server::{DnsClass, DnsName, DnsQuestion, DnsRecord, DnsType};
 use log::{debug, info};
 use permit::Permit;
 
@@ -45,6 +45,34 @@ fn resolver_handler(question: &DnsQuestion) -> Vec<DnsRecord> {
                 // Add names to ret
                 for rec in cache[&question.name.to_string()].aaaa.iter() {
                     ret.push(DnsRecord::AAAA(question.name.clone(), rec.parse().unwrap()));
+                }
+            }
+            debug!("ret: {:?}", ret);
+            ret
+        }
+        DnsType::CNAME => {
+            let mut ret = vec![];
+            debug!("Confirming CNAME record lookup for {:?}", question);
+            if cache.contains_key(&question.name.to_string()) {
+                for rec in cache[&question.name.to_string()].cname.iter() {
+                    ret.push(DnsRecord::CNAME(
+                        question.name.clone(),
+                        DnsName::new(rec).unwrap(),
+                    ));
+                }
+            }
+            debug!("ret: {:?}", ret);
+            ret
+        }
+        DnsType::NS => {
+            let mut ret = vec![];
+            debug!("Confirming NS record lookup for {:?}", question);
+            if cache.contains_key(&question.name.to_string()) {
+                for rec in cache[&question.name.to_string()].ns.iter() {
+                    ret.push(DnsRecord::NS(
+                        question.name.clone(),
+                        DnsName::new(rec).unwrap(),
+                    ));
                 }
             }
             debug!("ret: {:?}", ret);

--- a/rust/holo-dns/src/tests.rs
+++ b/rust/holo-dns/src/tests.rs
@@ -51,6 +51,8 @@ mod test {
             dns_cache::DnsCacheItem {
                 a: vec!["127.0.0.1".to_string()],
                 aaaa: vec!["::1".to_string()],
+                cname: vec!["x-cname-test.dna.holo.host".to_string()],
+                ns: vec!["x-service-test.dna.holo.host".to_string()],
             },
         );
         file.seek(SeekFrom::Start(0)).unwrap();

--- a/rust/holo-dns/test.json
+++ b/rust/holo-dns/test.json
@@ -1,6 +1,14 @@
 {
 	"gateway.web-bridge.holo.host": {
 		"aaaa": [ "::1" ],
-		"a": [ "127.0.0.1" ]
+		"a": [ "127.0.0.1" ],
+		"cname": [],
+		"ns": []
+	},
+	"web-bridge.holo.host": {
+		"a": [],
+		"aaaa": [],
+		"cname": [],
+		"ns": [ "gateway.web-bridge.holo.host" ]
 	}
 }

--- a/rust/util_libs/db/src/schemas.rs
+++ b/rust/util_libs/db/src/schemas.rs
@@ -567,6 +567,10 @@ pub struct PublicService {
     pub aaaa_addrs: Vec<String>,
     /// public IPv4 addresses the service is available on.
     pub a_addrs: Vec<String>,
+    /// FQDNs for CNAMES
+    pub cname_addrs: Vec<String>,
+    /// FQDNs for answers to NS record questions.
+    pub ns_addrs: Vec<String>,
 }
 
 /// Default implementation for PublicService to help initialise a few fields.
@@ -584,6 +588,8 @@ impl Default for PublicService {
             service_name: "".to_string(),
             aaaa_addrs: vec![],
             a_addrs: vec![],
+            cname_addrs: vec![],
+            ns_addrs: vec![],
         }
     }
 }


### PR DESCRIPTION
Closes #176. DNS service modified to include support for NS RRs added to upstream crate, and also CNAMEs. See `test.json` for examples. Note that none of the fields are optional, but any can be empty.
