### PR TITLE
201: Switch from branch to upstream dns-server crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1581,7 +1581,8 @@ dependencies = [
 [[package]]
 name = "dns-server"
 version = "0.2.5"
-source = "git+https://gitlab.com/matt.geddes/ops.git?branch=add-in-ns-rr#859924ebe6f989278d8a7b979574c9132cf8b100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dad9acd82165a4c6e0f42421e71bda4178224194388f3b4b56f34a6f3e3354d8"
 dependencies = [
  "fixed-buffer",
  "oorandom",
@@ -4765,7 +4766,8 @@ dependencies = [
 [[package]]
 name = "prob-rate-limiter"
 version = "0.1.1"
-source = "git+https://gitlab.com/matt.geddes/ops.git?branch=add-in-ns-rr#859924ebe6f989278d8a7b979574c9132cf8b100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22624ab4acf3a452d4452a1eb5efbdc9d2dbb18bdcafce67fcd59b3f7ecf6238"
 dependencies = [
  "oorandom",
 ]

--- a/rust/holo-dns/Cargo.toml
+++ b/rust/holo-dns/Cargo.toml
@@ -9,11 +9,7 @@ path = "bin/holo-dns.rs"
 
 
 [dependencies]
-# I have an open merge request with the upstream package maintainer for the NS record changes.
-# Once merged and a new crate is published, we ought to be able to use crate v0.2.5 instead of
-# the gitlab link below.
-#dns-server = "0.2.4"
-dns-server = { git = "https://gitlab.com/matt.geddes/ops.git", branch = "add-in-ns-rr" }
+dns-server = "0.2.5"
 env_logger = { workspace = true }
 log = { workspace = true }
 permit = "0.2.1"


### PR DESCRIPTION
Closes #201.

Our PR against the upstream crate was approved, merged and released. This PR removes the reference to my repo/branch and replaces it with the crates.io version number.