### PR TITLE
Bug 254: Added memory and OS release info to inventory

### DIFF
--- a/rust/hpos-hal/src/inventory.rs
+++ b/rust/hpos-hal/src/inventory.rs
@@ -14,6 +14,9 @@ use std::fs::OpenOptions;
 use std::io;
 use std::io::Read;
 use std::path::Path;
+// Using fork/exec unnecessarily will make the inventory collection too expensive to run as often
+// as we are going to need to. It is almost never necessary.
+use std::process::Command;
 use std::{fs, fs::File};
 use thiserror::Error;
 use thiserror_context::{impl_context, Context};
@@ -74,6 +77,8 @@ pub struct HoloInventory {
     /// Information about CPUs present. All CPUs are generally the same in the x86_64 case, but may
     /// be different on other architectures, such as aarch64.
     pub cpus: Vec<HoloProcessorInventory>,
+    /// Inventory of memory DIMM devices
+    pub mem: Vec<HoloMemoryInventory>,
     /// An inventory of USB devices specifically. May overlap with other sections (eg, USB storage
     /// devices).
     pub usb: Vec<HoloUsbInventory>,
@@ -130,6 +135,10 @@ pub struct HoloSystemInventory {
     pub kernel_version: String,
     /// OpenSSH Host public keys.
     pub ssh_host_keys: Vec<SSHPubKey>,
+    /// Distribution release string
+    pub distribution_release: String,
+    /// Package manager version/release string
+    pub package_mgr_release: String,
 }
 
 /// A data structure representing an OpenSSH public key. When stored, each key is a single line of
@@ -511,9 +520,12 @@ impl HoloInventory {
                 machine_id: systemd_machine_id(),
                 kernel_version: linux_kernel_build(),
                 ssh_host_keys: ssh_host_keys(),
+                distribution_release: get_distro_release(),
+                package_mgr_release: get_package_mgr_release(),
             },
             drives: HoloDriveInventory::from_host(),
             cpus: HoloProcessorInventory::from_host(),
+            mem: HoloMemoryInventory::from_host(),
             nics: HoloNicInventory::from_host(),
             usb: HoloUsbInventory::from_host(),
             platform: None,
@@ -797,6 +809,48 @@ impl HoloProcessorInventory {
     }
 }
 
+/// A struct representing a memory object
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Default, Clone)]
+pub struct HoloMemoryInventory {
+    pub size: u64,
+    pub form_factor: String,
+    pub memory_type: String,
+    pub memory_speed: u16,
+}
+
+impl HoloMemoryInventory {
+    const SMBIOS_MEMORY_PATH_GLOB: &str = "/sys/firmware/dmi/entries/17-*/raw";
+
+    pub fn from_host() -> Vec<HoloMemoryInventory> {
+        let mut ret: Vec<HoloMemoryInventory> = vec![];
+
+        info!("Checking memory glob: {}", Self::SMBIOS_MEMORY_PATH_GLOB);
+
+        match glob(Self::SMBIOS_MEMORY_PATH_GLOB) {
+            Ok(mem_devs) => {
+                for mem_dev in mem_devs {
+                    debug!("Mem dev: {:?}", mem_dev);
+                    match mem_dev {
+                        Ok(mem) => {
+                            let Ok(res) = sysfs::parse_mem_file(mem.to_string_lossy().as_ref())
+                            else {
+                                continue;
+                            };
+                            ret.push(res);
+                        }
+                        Err(e) => {
+                            info!("Failed to parse mem dev: {}", e);
+                        }
+                    }
+                }
+            }
+            Err(e) => info!("Memory glob failed with: {}", e),
+        }
+
+        ret
+    }
+}
+
 /// This is the glob patch to match all OpenSSH host _public_ keys. We never touch the private key.
 const SSHD_HOST_KEY_GLOB: &str = "/etc/ssh/ssh_host_*_key.pub";
 
@@ -859,4 +913,68 @@ fn linux_kernel_build() -> String {
     };
 
     ret
+}
+
+const NIXOS_VERSION_WRAPPER: &str = "/run/current-system/sw/bin/nixos-version";
+/// Get operating system distribution release string
+fn get_distro_release() -> String {
+    // See if we're running on NixOS and handle that case.
+    if Path::new(NIXOS_VERSION_WRAPPER).exists() {
+        // This is utterly heinous. Unlike any LSB-compliant Linux distribution, where we can
+        // simply read a file to get the version string, NixOS makes us fork/exec symlinks to
+        // wrapper scripts to shell scripts that have the release string hard-coded in them. The
+        // inventory is supposed to be lightweight and we go to reasonable lengths to avoid this
+        // collection just being a shell script written in Rust. Calling fork/exec like this is
+        // only ever done as a last resort.
+        let output = Command::new(NIXOS_VERSION_WRAPPER).output();
+        match output {
+            Ok(output) => match output.status.success() {
+                true => {
+                    return String::from_utf8_lossy(&output.stdout)
+                        .strip_suffix("\n")
+                        .unwrap_or_default()
+                        .to_string()
+                }
+                false => return "Unknown NixOS release".to_string(),
+            },
+            Err(e) => {
+                info!("Failed to execute nixos-version: {}", e);
+                return "Unknown NixOS release".to_string();
+            }
+        }
+    }
+
+    // We'll add support for other distributions later for the sake of completeness. But this will
+    // suffice for now.
+    "Undetected".to_string()
+}
+
+const NIX_VERSION_WRAPPER: &str = "/run/current-system/sw/bin/nix";
+/// Get primary package manager release string.
+fn get_package_mgr_release() -> String {
+    // See if we're running on NixOS and handle that case.
+    if Path::new(NIX_VERSION_WRAPPER).exists() {
+        // See above comment around the heinous nature of having to fork/exec wrappers to retrieve
+        // a version string.
+        let output = Command::new(NIX_VERSION_WRAPPER).arg("--version").output();
+        match output {
+            Ok(output) => match output.status.success() {
+                true => {
+                    return String::from_utf8_lossy(&output.stdout)
+                        .strip_suffix("\n")
+                        .unwrap_or_default()
+                        .to_string()
+                }
+                false => return "Unknown Nix release".to_string(),
+            },
+            Err(e) => {
+                info!("Failed to execute nix --version: {}", e);
+                return "Unknown Nix release".to_string();
+            }
+        }
+    }
+
+    // We'll add support for other distributions later for the sake of completeness. But this will
+    // suffice for now.
+    "Undetected".to_string()
 }

--- a/rust/hpos-hal/src/sysfs.rs
+++ b/rust/hpos-hal/src/sysfs.rs
@@ -326,9 +326,7 @@ pub fn parse_mem_file(path: &str) -> Result<crate::inventory::HoloMemoryInventor
     let mem = SMBiosMemoryInfo::read(&mut f)?;
     debug!("Parsed memory structure: {:?}", mem);
     Ok(HoloMemoryInventory {
-        // TODO: Size isn't always in kB blocks. If mem.size is 0x7fff, we should use
-        // extended_size. That'll only happen for DIMMs of 32GB+.
-        size_kb: mem.mem_size(),
+        size: mem.mem_size(),
         form_factor: mem.form_factor.to_string(),
         memory_type: mem.memory_type.to_string(),
         memory_speed: mem.speed_mts,

--- a/rust/hpos-hal/src/sysfs.rs
+++ b/rust/hpos-hal/src/sysfs.rs
@@ -1,8 +1,10 @@
-use crate::inventory::InventoryBusType;
+use crate::inventory::{HoloMemoryInventory, InventoryBusType};
 /// This module is used internally as a wrapper for pulling values from files under /sys. As with
 /// anything else in the inventiry module, this is generally best-effort. We can't fail something
 /// here and bubble it all the way up with '?' and have it not handled.
-use log::info;
+use binrw::*;
+use log::{debug, info};
+use std::fmt::{self, Display};
 use std::fs;
 
 pub fn string_attr(filename: String) -> Option<String> {
@@ -69,4 +71,266 @@ pub fn bus_by_device_link(filename: &str) -> InventoryBusType {
     }
 
     InventoryBusType::UNKNOWN
+}
+
+/// See the SMBIOS spec, table 74 (Memory device structure for type 17). We really only use a few
+/// fields from this structure to identify key device attributes.
+#[derive(BinRead, Debug, PartialEq)]
+#[br(little)]
+pub struct SMBiosMemoryInfo {
+    // dev_type is the SMBIOS type and should always be 17. Assert that as a sanity check.
+    //dev_type: u8,
+    #[brw(magic = 17u8)]
+    // The data structure length will be at least 0x28 bytes in length if it's a data structure of
+    // version 2.8 or later. The holoport SMBIOS version is 3.0.0. We ought to not have to deal
+    // with anything older.
+    #[br(assert(struct_len > 0x27))]
+    struct_len: u8,
+    handle: u16,
+    phys_handle: u16,
+    err_handle: u16,
+    total_width: u16,
+    data_width: u16,
+    size: u16,
+    form_factor: MemoryFormFactor,
+    device_set: u8,
+    // the follow values are indexes within the string table. Once we add code to parse the string
+    // table part of the struct, these will point to the item in the string table vector/slice.
+    device_locator_string_index: u8,
+    bank_locator_string_index: u8,
+    memory_type: MemoryType,
+    // This is a bitmask
+    type_detail: u16,
+    speed_mts: u16,
+    manufacturer_string_index: u8,
+    serial_string_index: u8,
+    asset_string_index: u8,
+    part_string_index: u8,
+    attributes: u8,
+    extended_size: u16,
+    configured_speed_mts: u16,
+    minimum_voltage: u16,
+    maximum_voltage: u16,
+    configured_voltage: u16,
+    memory_tech: u8,
+    memory_modes: u16,
+    firmware_version_index: u8,
+    manufacturer_id: u16,
+    product_id: u16,
+    sub_manufacturer_id: u16,
+    sub_product_id: u16,
+    nonvolatile_size: u32,
+    volatile_size: u32,
+    cache_size: u32,
+    logical_size: u32,
+}
+
+impl SMBiosMemoryInfo {
+    /// This determines the capacity of the memory module in bytes using the magic incantation
+    /// carved in runes in table 74 of the SMBIOS spec version 3.2.
+    fn mem_size(&self) -> u64 {
+        if self.size == 0x7fff {
+            // 7.18.5 -- extended size
+            self.extended_size as u64 * 1024_u64 * 1024_u64
+        } else if self.size == 0xffff {
+            // undetermined size
+            0
+        } else if (self.size & 0x8000) > 0 {
+            // Size is in kilobytes
+            self.size as u64 * 1024_u64
+        } else {
+            // size is in megabytes
+            self.size as u64 * 1024_u64 * 1024_u64
+        }
+    }
+}
+
+// Table 7.18.1 - Memory device form factor from SMBIOS spec
+#[derive(BinRead, Debug, PartialEq)]
+pub enum MemoryFormFactor {
+    #[br(magic = 0u8)]
+    Invalid,
+    #[br(magic = 1u8)]
+    Other,
+    #[br(magic = 2u8)]
+    Unknown,
+    #[br(magic = 3u8)]
+    SIMM,
+    #[br(magic = 4u8)]
+    SIP,
+    // Who doesn't like chips...
+    #[br(magic = 5u8)]
+    Chip,
+    // ... and dip?
+    #[br(magic = 6u8)]
+    DIP,
+    #[br(magic = 7u8)]
+    ZIP,
+    #[br(magic = 8u8)]
+    Proprietary,
+    #[br(magic = 9u8)]
+    DIMM,
+    #[br(magic = 10u8)]
+    TSOP,
+    #[br(magic = 11u8)]
+    ChipRow,
+    #[br(magic = 12u8)]
+    RIMM,
+    // Most common for hardware we'll be dealing with.
+    #[br(magic = 13u8)]
+    SODIMM,
+    #[br(magic = 14u8)]
+    SRIMM,
+    #[br(magic = 15u8)]
+    FBDIMM,
+}
+
+impl Display for MemoryFormFactor {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Self::Invalid => write!(f, "Invalid"),
+            Self::Other => write!(f, "Other"),
+            Self::Unknown => write!(f, "Unknown"),
+            Self::SIMM => write!(f, "SIMM"),
+            Self::SIP => write!(f, "SIP"),
+            Self::Chip => write!(f, "Chip"),
+            Self::DIP => write!(f, "DIP"),
+            Self::ZIP => write!(f, "ZIP"),
+            Self::Proprietary => write!(f, "Proprietary"),
+            Self::DIMM => write!(f, "DIMM"),
+            Self::TSOP => write!(f, "TSOP"),
+            Self::ChipRow => write!(f, "Row of Chips"),
+            Self::RIMM => write!(f, "RIMM"),
+            Self::SODIMM => write!(f, "SODIMM"),
+            Self::SRIMM => write!(f, "SRIMM"),
+            Self::FBDIMM => write!(f, "FBDIMM"),
+        }
+    }
+}
+
+// Table 7.18.2 - Memory device type from SMBIOS spec
+#[derive(BinRead, Debug, PartialEq)]
+pub enum MemoryType {
+    #[br(magic = 0u8)]
+    Invalid,
+    #[br(magic = 1u8)]
+    Other,
+    #[br(magic = 2u8)]
+    Unknown,
+    #[br(magic = 3u8)]
+    DRAM,
+    #[br(magic = 4u8)]
+    EDRAM,
+    #[br(magic = 5u8)]
+    VRAM,
+    #[br(magic = 6u8)]
+    SRAM,
+    #[br(magic = 7u8)]
+    RAM,
+    #[br(magic = 8u8)]
+    ROM,
+    #[br(magic = 9u8)]
+    FLASH,
+    #[br(magic = 10u8)]
+    EEPROM,
+    #[br(magic = 11u8)]
+    FEPROM,
+    #[br(magic = 12u8)]
+    EPROM,
+    #[br(magic = 13u8)]
+    CDRAM,
+    #[br(magic = 14u8)]
+    THREEDRAM,
+    #[br(magic = 15u8)]
+    SDRAM,
+    #[br(magic = 16u8)]
+    SGRAM,
+    #[br(magic = 17u8)]
+    RDRAM,
+    #[br(magic = 18u8)]
+    DDR,
+    #[br(magic = 19u8)]
+    DDR2,
+    #[br(magic = 20u8)]
+    DDR2FBDIMM,
+    #[br(magic = 21u8)]
+    Reserved1,
+    #[br(magic = 22u8)]
+    Reserved2,
+    #[br(magic = 23u8)]
+    Reserved3,
+    #[br(magic = 24u8)]
+    DDR3,
+    #[br(magic = 25u8)]
+    FBD2,
+    #[br(magic = 26u8)]
+    DDR4,
+    #[br(magic = 27u8)]
+    LPDDR,
+    #[br(magic = 28u8)]
+    LPDDR2,
+    #[br(magic = 29u8)]
+    LPDDR3,
+    #[br(magic = 30u8)]
+    LPDDR4,
+    #[br(magic = 31u8)]
+    LNVRAM,
+}
+
+impl Display for MemoryType {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Self::Invalid => write!(f, "Invalid"),
+            Self::Other => write!(f, "Other"),
+            Self::Unknown => write!(f, "Unknown"),
+            Self::DRAM => write!(f, "DRAM"),
+            Self::EDRAM => write!(f, "EDRAM"),
+            Self::RAM => write!(f, "RAM"),
+            Self::VRAM => write!(f, "VRAM"),
+            Self::SRAM => write!(f, "SRAM"),
+            Self::ROM => write!(f, "ROM"),
+            Self::FLASH => write!(f, "FLASH"),
+            Self::EEPROM => write!(f, "EEPROM"),
+            Self::FEPROM => write!(f, "FEPROM"),
+            Self::EPROM => write!(f, "EPROM"),
+            Self::CDRAM => write!(f, "CDRAM"),
+            Self::THREEDRAM => write!(f, "THREEDRAM"),
+            Self::SDRAM => write!(f, "SDRAM"),
+            Self::SGRAM => write!(f, "SGRAM"),
+            Self::RDRAM => write!(f, "RDRAM"),
+            Self::DDR => write!(f, "DDR"),
+            Self::DDR2 => write!(f, "DDR2"),
+            Self::DDR2FBDIMM => write!(f, "DDR2FBDIMM"),
+            Self::Reserved1 => write!(f, "Reserved1"),
+            Self::Reserved2 => write!(f, "Reserved2"),
+            Self::Reserved3 => write!(f, "Reserved3"),
+            Self::DDR3 => write!(f, "DDR3"),
+            Self::FBD2 => write!(f, "FBD2"),
+            Self::DDR4 => write!(f, "DDR4"),
+            Self::LPDDR => write!(f, "LPDDR"),
+            Self::LPDDR2 => write!(f, "LPDDR2"),
+            Self::LPDDR3 => write!(f, "LPDDR3"),
+            Self::LPDDR4 => write!(f, "LPDDR4"),
+            Self::LNVRAM => write!(f, "LNVRAM"),
+        }
+    }
+}
+
+/// Parse an SMBIOS type 17 struct. There's a lot of other useful information in here, including
+/// things like memory speed and manufacturer and model strings. Those will be useful to add later,
+/// but for now, having each memory "slot" and the capacity in it will be super useful. Note that a
+/// "slot" no longer equates to a physical memory slot on the board, and in many hardware cases,
+/// there are no slots at all and the memory is soldered to the board...
+pub fn parse_mem_file(path: &str) -> Result<crate::inventory::HoloMemoryInventory, Error> {
+    let mut f = std::fs::File::open(path)?;
+    let mem = SMBiosMemoryInfo::read(&mut f)?;
+    debug!("Parsed memory structure: {:?}", mem);
+    Ok(HoloMemoryInventory {
+        // TODO: Size isn't always in kB blocks. If mem.size is 0x7fff, we should use
+        // extended_size. That'll only happen for DIMMs of 32GB+.
+        size_kb: mem.mem_size(),
+        form_factor: mem.form_factor.to_string(),
+        memory_type: mem.memory_type.to_string(),
+        memory_speed: mem.speed_mts,
+    })
 }

--- a/rust/hpos-hal/src/tests.rs
+++ b/rust/hpos-hal/src/tests.rs
@@ -80,7 +80,14 @@ fn parse_ext4() {
 
 #[test]
 fn machine_id() {
+    env_logger::init();
     let inv = HoloInventory::from_host();
+
+    log::debug!("Inventory: {:?}", inv);
+
+    // This test runs as a non-root user, so we shouldn't get any memory information back, but the
+    // inventory should still come back with other stuff.
+    assert_eq!(inv.mem.len(), 0);
 
     let mut machine_cmd = assert_cmd::Command::new("systemd-machine-id-setup");
     let assert = machine_cmd.arg("--print").assert();
@@ -209,6 +216,11 @@ fn smbios_board() {
         None => "".to_string(),
     };
     assert.stdout(format!("{}\n", board_name));
+
+    // Simple check for memory data. We don't know anything about the machine(s) this test will run
+    // on, so it could come back with anything. It's probably worth collecting a few example of
+    // blobs and checking those in as mock structs.
+    assert_ne!(inv.mem.len(), 0);
 }
 
 // dmidecode translates raw values into strings for a lot of these parameters. These tests will


### PR DESCRIPTION
This resolves #254 in holo-host-private. I've added some initial information about memory modules present. It could use some additional work later, but works fine on my holoport and some other hosts I have around the house. I've also included the output of `nix --version` and `nixos-version`.
