### PR TITLE
feat: add host-updates service and clients

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2981,6 +2981,7 @@ version = "0.0.1"
 dependencies = [
  "anyhow",
  "async-nats",
+ "async-trait",
  "base32",
  "bson",
  "bytes",
@@ -3001,6 +3002,7 @@ dependencies = [
  "serde_json",
  "serial_test",
  "sha2",
+ "strum_macros 0.25.3",
  "tempfile",
  "tokio",
 ]
@@ -4564,6 +4566,7 @@ dependencies = [
  "dotenv",
  "env_logger",
  "futures",
+ "hpos_updates",
  "inventory",
  "log",
  "mongodb",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,7 +54,7 @@ dependencies = [
  "flate2",
  "foldhash",
  "futures-core",
- "h2 0.3.26",
+ "h2 0.3.27",
  "http 0.2.12",
  "httparse",
  "httpdate",
@@ -64,7 +64,7 @@ dependencies = [
  "mime",
  "percent-encoding",
  "pin-project-lite",
- "rand 0.9.1",
+ "rand 0.9.2",
  "sha1",
  "smallvec",
  "tokio",
@@ -80,7 +80,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e01ed3140b2f8d422c68afa1ed2e85d996ea619c988ac834d255db32138655cb"
 dependencies = [
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -118,7 +118,7 @@ dependencies = [
  "parse-size",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -128,7 +128,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13d324164c51f63867b57e73ba5936ea151b8a41a1d23d1031eeb9f70d0236f8"
 dependencies = [
  "bytestring",
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "http 0.2.12",
  "regex",
  "regex-lite",
@@ -158,7 +158,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "mio",
- "socket2",
+ "socket2 0.5.10",
  "tokio",
  "tracing",
 ]
@@ -200,7 +200,7 @@ dependencies = [
  "actix-web-codegen",
  "bytes",
  "bytestring",
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "cookie",
  "derive_more 2.0.1",
  "encoding_rs",
@@ -220,7 +220,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "smallvec",
- "socket2",
+ "socket2 0.5.10",
  "time",
  "tracing",
  "url",
@@ -235,7 +235,7 @@ dependencies = [
  "actix-router",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -249,9 +249,9 @@ dependencies = [
 
 [[package]]
 name = "adler2"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "adler32"
@@ -265,7 +265,7 @@ version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "getrandom 0.3.3",
  "once_cell",
  "version_check",
@@ -328,9 +328,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.18"
+version = "0.6.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
+checksum = "301af1932e46185686725e0fad2f8f2aa7da69dd70bf6ecc44d6b703844a3933"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -343,33 +343,33 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
+checksum = "6c8bdeb6047d8983be085bab0ba1472e6dc604e7041dbf6fcd5e71523014fae9"
 dependencies = [
  "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.8"
+version = "3.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6680de5231bd6ee4c6191b8a1325daa282b415391ec9d3a37bd34f2060dc73fa"
+checksum = "403f75924867bb1033c59fbf0797484329750cfbe3c4325cd33127941fabc882"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
@@ -500,7 +500,7 @@ checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -522,9 +522,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "automap"
@@ -532,7 +532,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b99d887f4066f8a1b4a713a8121fab07ff543863ac86177ebdee6b5cb18acf12"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "derive_more 0.99.20",
  "serde",
  "shrinkwraprs",
@@ -540,9 +540,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.13.1"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93fcc8f365936c834db5514fc45aee5b1202d677e6b40e48468aaaa8183ca8c7"
+checksum = "5c953fe1ba023e6b7730c0d4b031d06f267f23a46167dcbd40316644b10a17ba"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -550,9 +550,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61b1d86e7705efe1be1b569bab41d4fa1e14e220b60a160f78de2db687add079"
+checksum = "dbfd150b5dbdb988bcc8fb1fe787eb6b7ee6180ca24da683b61ea5405f3d43ff"
 dependencies = [
  "bindgen",
  "cc",
@@ -622,7 +622,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002"
 dependencies = [
  "addr2line",
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "libc",
  "miniz_oxide",
  "object",
@@ -662,9 +662,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64ct"
-version = "1.7.3"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89e25b6adfb930f02d1981565a6e5d9c547ac15a96606256d3b59040e5cd4ca3"
+checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
 
 [[package]]
 name = "bincode"
@@ -694,7 +694,7 @@ dependencies = [
  "regex",
  "rustc-hash 1.1.0",
  "shlex",
- "syn 2.0.101",
+ "syn 2.0.104",
  "which",
 ]
 
@@ -799,7 +799,7 @@ dependencies = [
  "arrayref",
  "arrayvec",
  "cc",
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "constant_time_eq",
 ]
 
@@ -846,10 +846,10 @@ dependencies = [
  "getrandom 0.2.16",
  "getrandom 0.3.3",
  "hex",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "js-sys",
  "once_cell",
- "rand 0.9.1",
+ "rand 0.9.2",
  "serde",
  "serde_bytes",
  "serde_json",
@@ -870,15 +870,15 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.17.0"
+version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
+checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
 name = "bytemuck"
-version = "1.23.0"
+version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9134a6ef01ce4b366b50689c94f82c14bc72bc5d0386829828a2e2752ef7958c"
+checksum = "5c76a5792e44e4abe34d3abf15636779261d45a7450612059293d1d2cfc63422"
 
 [[package]]
 name = "byteorder"
@@ -906,9 +906,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.25"
+version = "1.2.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0fc897dc1e865cc67c0e05a836d9d3f1df3cbe442aa4a9473b18e12624a4951"
+checksum = "deec109607ca693028562ed836a5f1c4b8bd77755c4e132fc5ce11b0b6211ae7"
 dependencies = [
  "jobserver",
  "libc",
@@ -932,9 +932,9 @@ checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
 name = "cfg-if"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
 name = "cfg_aliases"
@@ -985,9 +985,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.39"
+version = "4.5.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd60e63e9be68e5fb56422e397cf9baddded06dae1d2e523401542383bc72a9f"
+checksum = "be92d32e80243a54711e5d7ce823c35c41c9d929dc4ab58e1276f625841aadf9"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -995,9 +995,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.39"
+version = "4.5.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89cc6392a1f72bbeb820d71f32108f61fdaf18bc526e1d23954168a67759ef51"
+checksum = "707eab41e9622f9139419d573eca0900137718000c517d47da73045f54331c3d"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1007,21 +1007,21 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.32"
+version = "4.5.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09176aae279615badda0765c0c0b3f6ed53f4709118af73cf4655d85d1530cd7"
+checksum = "ef4f52386a59ca4c860f7393bcf8abd8dfd91ecccc0f774635ff68e92eeef491"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
+checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 
 [[package]]
 name = "cmake"
@@ -1034,9 +1034,9 @@ dependencies = [
 
 [[package]]
 name = "colorchoice"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "colored"
@@ -1064,9 +1064,9 @@ dependencies = [
 
 [[package]]
 name = "config"
-version = "0.15.11"
+version = "0.15.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "595aae20e65c3be792d05818e8c63025294ac3cb7e200f11459063a352a6ef80"
+checksum = "5b1eb4fb07bc7f012422df02766c7bd5971effb894f573865642f06fa3265440"
 dependencies = [
  "async-trait",
  "convert_case 0.6.0",
@@ -1076,7 +1076,7 @@ dependencies = [
  "rust-ini",
  "serde",
  "serde_json",
- "toml 0.8.22",
+ "toml 0.9.2",
  "winnow",
  "yaml-rust2",
 ]
@@ -1185,11 +1185,11 @@ dependencies = [
 
 [[package]]
 name = "crc32fast"
-version = "1.4.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
 ]
 
 [[package]]
@@ -1228,9 +1228,9 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crunchy"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -1249,7 +1249,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a2785755761f3ddc1492979ce1e48d2c00d09311c39e4466429188f3dd6501"
 dependencies = [
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1258,7 +1258,7 @@ version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "cpufeatures",
  "curve25519-dalek-derive",
  "digest",
@@ -1276,7 +1276,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1324,7 +1324,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.11.1",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1346,7 +1346,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core 0.20.11",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1361,7 +1361,7 @@ version = "5.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "hashbrown 0.14.5",
  "lock_api",
  "once_cell",
@@ -1374,7 +1374,7 @@ version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "crossbeam-utils",
  "hashbrown 0.14.5",
  "lock_api",
@@ -1398,7 +1398,7 @@ dependencies = [
  "bson",
  "bytes",
  "chrono",
- "clap 4.5.39",
+ "clap 4.5.41",
  "ctor",
  "derive_more 1.0.0",
  "dotenv",
@@ -1415,7 +1415,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "strum 0.27.1",
+ "strum 0.27.2",
  "tempfile",
  "thiserror 2.0.12",
  "tokio",
@@ -1494,18 +1494,18 @@ checksum = "d65d7ce8132b7c0e54497a4d9a55a1c2a0912a0d786cf894472ba818fba45762"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
 name = "derive-where"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e73f2692d4bd3cac41dca28934a39894200c9fabf49586d77d0e5954af1d7902"
+checksum = "510c292c8cf384b1a340b816a9a6cf2599eb8f566a44949024af88418000c50b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1516,7 +1516,7 @@ checksum = "30542c1ad912e0e3d22a1935c290e12e8a29d704a420177a31faad4a601a0800"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1537,7 +1537,7 @@ dependencies = [
  "darling 0.20.11",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1547,7 +1547,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1560,7 +1560,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1589,7 +1589,7 @@ checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
  "unicode-xid",
 ]
 
@@ -1601,7 +1601,7 @@ checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
  "unicode-xid",
 ]
 
@@ -1636,7 +1636,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1685,6 +1685,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c7a8fb8a9fbf66c1f703fe16184d10ca0ee9d23be5b4436400408ba54a95005"
+
+[[package]]
 name = "ed25519"
 version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1696,9 +1702,9 @@ dependencies = [
 
 [[package]]
 name = "ed25519-dalek"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a3daa8e81a3963a60642bcc1f90a670680bd4a77535faa384e9d1c79d620871"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
@@ -1719,7 +1725,7 @@ dependencies = [
  "enum-ordinalize",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1734,7 +1740,7 @@ version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
 ]
 
 [[package]]
@@ -1746,7 +1752,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1766,7 +1772,7 @@ checksum = "0d28318a75d4aead5c4db25382e8ef717932d0346600cacae6357eb5941bc5ff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1800,12 +1806,12 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea14ef9355e3beab063703aa9dab15afd25f0667c341310c1e5274bb1d0da18"
+checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1872,7 +1878,7 @@ version = "0.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35c0522e981e68cbfa8c3f978441a5f34b30b96e146b33cd3359176b50fe8586"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "libc",
  "libredox",
  "windows-sys 0.59.0",
@@ -1886,9 +1892,9 @@ checksum = "40ee7fb99bb4329360810b25714a7a39aa1a716da90692d97b98adcca6ca0152"
 
 [[package]]
 name = "fixt"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "880b97dc7ddd361f39c469311e7eeceb0a467b8d3dce155fcbadb18ceeba814f"
+checksum = "922899b30f14c5e2271035f7c0c6bdc3ae01c28fc9c69caa98f5e1a7f5340d57"
 dependencies = [
  "holochain_serialized_bytes",
  "lazy_static",
@@ -1903,9 +1909,9 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ced92e76e966ca2fd84c8f7aa01a4aea65b0eb6648d72f7c8f3e2764a67fece"
+checksum = "4a3d7db9596fecd151c5f638c0ee5d5bd487b6e0ea232e5dc96d5250f6f94b1d"
 dependencies = [
  "crc32fast",
  "libz-rs-sys",
@@ -2001,7 +2007,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -2062,7 +2068,7 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "libc",
  "wasi 0.9.0+wasi-snapshot-preview1",
 ]
@@ -2073,10 +2079,10 @@ version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "js-sys",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi 0.11.1+wasi-snapshot-preview1",
  "wasm-bindgen",
 ]
 
@@ -2086,7 +2092,7 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "js-sys",
  "libc",
  "r-efi",
@@ -2123,9 +2129,9 @@ checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
 name = "h2"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
+checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
 dependencies = [
  "bytes",
  "fnv",
@@ -2133,7 +2139,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -2142,9 +2148,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9421a676d1b147b16b82c9225157dc629087ef8ec4d5e2960f9437a90dac0a5"
+checksum = "17da50a276f1e01e0ba6c029e47b7100754904ee8a278f886546e98575380785"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2152,7 +2158,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.3.1",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -2166,7 +2172,7 @@ dependencies = [
  "anyhow",
  "base64 0.22.1",
  "bytes",
- "clap 4.5.39",
+ "clap 4.5.41",
  "derive_builder",
  "holochain_client",
  "holochain_conductor_api",
@@ -2200,9 +2206,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.3"
+version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
+checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
 dependencies = [
  "allocator-api2",
  "equivalent",
@@ -2224,7 +2230,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
 dependencies = [
- "hashbrown 0.15.3",
+ "hashbrown 0.15.4",
 ]
 
 [[package]]
@@ -2254,10 +2260,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "hdi"
-version = "0.5.3"
+name = "hc_serde_json"
+version = "1.0.141"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04bed1d57dd7f72adcc6f07bb8048851984c4d6cf1f083df307dd86c97bed894"
+checksum = "049eba3ff81c89d682e35e0b6de79cb6d359fe37198f686213915ad57b694b42"
+dependencies = [
+ "itoa",
+ "memchr",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "hdi"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe50ccf3bbd2364ed124df15b9b071f870e8119455bea5373f841793c377a7fb"
 dependencies = [
  "getrandom 0.2.16",
  "hdk_derive",
@@ -2273,9 +2291,9 @@ dependencies = [
 
 [[package]]
 name = "hdk"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3994bfc954b99f92b30455f886d37a00adb10e596f552a62dc4d09c883c63cb3"
+checksum = "a8741556cb2c7ffa3c0beca7443e1bf77137f957bf91b5cad032ec90d33db4b4"
 dependencies = [
  "getrandom 0.2.16",
  "hdi",
@@ -2293,9 +2311,9 @@ dependencies = [
 
 [[package]]
 name = "hdk_derive"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3031f97449357727027d010effe66da513fee5504ccea7fc8b781d0b3e59c688"
+checksum = "7ff65a79319fd5b7655c722fdf7aeccec6a56369356a73ce2d018e4254e89fec"
 dependencies = [
  "darling 0.14.4",
  "heck 0.5.0",
@@ -2339,9 +2357,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f154ce46856750ed433c8649605bf7ed2de3bc35fd9d2a9f30cddd873c80cb08"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -2356,7 +2374,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92652067c9ce6f66ce53cc38d1169daa36e6e7eb7dd3b63b5103bd9d97117248"
 dependencies = [
  "async-trait",
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "data-encoding",
  "enum-as-inner",
  "futures-channel",
@@ -2379,7 +2397,7 @@ version = "0.24.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cbb117a1ca520e111743ab2f6688eddee69db4e0ea242545a604dce8a66fd22e"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "futures-util",
  "hickory-proto",
  "ipconfig",
@@ -2430,7 +2448,7 @@ dependencies = [
  "anyhow",
  "async-nats",
  "bytes",
- "clap 4.5.39",
+ "clap 4.5.41",
  "env_logger",
  "futures",
  "holochain_http_gateway",
@@ -2474,7 +2492,7 @@ dependencies = [
  "redis 0.30.0",
  "serde",
  "serde_json",
- "strum 0.27.1",
+ "strum 0.27.2",
  "tracing",
  "tracing-subscriber",
  "url",
@@ -2484,9 +2502,9 @@ dependencies = [
 
 [[package]]
 name = "holo_hash"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1778faf76d3976dcb4178d434f29055b22de136db802b7e738c8c1a4412fa845"
+checksum = "a1d9fef9ab9773471acccfad3aad43818565e382bbf3678bbf693e4cf5cf6c61"
 dependencies = [
  "base64 0.22.1",
  "blake2b_simd",
@@ -2533,11 +2551,11 @@ dependencies = [
 
 [[package]]
 name = "holochain_conductor_api"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37fc8d03b024b36cdcfed3937ebf0430a1522e84210efe247b622b71d11aff0b"
+checksum = "02fa9b74458847df0f7d547fb83fa255fb4d2941b095ac164ba48cbddd83885e"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "derive_more 0.99.20",
  "holo_hash",
  "holochain_keystore",
@@ -2558,21 +2576,21 @@ dependencies = [
 
 [[package]]
 name = "holochain_http_gateway"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "261f5cc52685265e600617346f8203714020d2f044d4953cc8cd5b2c7588aa0a"
+checksum = "165ff67828dd7b2eb899f1384da2f784f5cd1f779251c1cf8a5e8831499d9445"
 dependencies = [
  "anyhow",
  "axum",
  "base64 0.22.1",
- "clap 4.5.39",
+ "clap 4.5.41",
  "futures",
+ "hc_serde_json",
  "holochain_client",
  "holochain_conductor_api",
  "holochain_types",
  "holochain_websocket",
  "serde",
- "serde_json",
  "thiserror 2.0.12",
  "tokio",
  "tracing",
@@ -2582,9 +2600,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_integrity_types"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02262ebb640d0408eed613ddd223a88610a127843927e2f2befe7c7cafa93882"
+checksum = "fa398d4b6eec2d35adf166f91a3cf5206cf1adaf61c7617fc83da2e1ee80cfd4"
 dependencies = [
  "derive_builder",
  "holo_hash",
@@ -2601,9 +2619,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_keystore"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5519aa89f31709196ac2e8a028b3191cdff7e7407ce219d951e2ec6f582a6f4d"
+checksum = "3f5a31ec6595e8b6964fca98148bec4cd805c099b59be12ff7854875133e2849"
 dependencies = [
  "base64 0.22.1",
  "derive_more 0.99.20",
@@ -2630,9 +2648,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_nonce"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a82fb403005f04fc3827db1877634975bae8047db59b872898e2fdebe7f560f9"
+checksum = "a7b92e005934a961abf19586065dd725788946cd1dfa994bc7b114410c8671c5"
 dependencies = [
  "getrandom 0.2.16",
  "holochain_secure_primitive",
@@ -2641,9 +2659,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_secure_primitive"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cce3ecf87666c2b1a57d8f144a24c3693a1849451a74c2fc06a8e222340cedd"
+checksum = "1b422e7aab2f8bc014e03911aa19d5c519926245b6489b7f08113c45f5e30d39"
 dependencies = [
  "paste",
  "serde",
@@ -2677,9 +2695,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_sqlite"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a94248c6c2da3e2cf1554a0b4affc965051bacddefb5511fdf75c8c44eeab806"
+checksum = "f57a9c1fadd14e1640d950f23856ba8e9c38a3ba949b0292435b09f6e47dd644"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2722,9 +2740,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_state_types"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f15149b6c83798defbc5b3492889fb0cad6109bd5559300dbf288df3afb89a"
+checksum = "b63e7fed9415d3883bc700c701fff253a3a0f6c1d045d4ce1937e15f58f6f224"
 dependencies = [
  "holo_hash",
  "holochain_integrity_types",
@@ -2733,9 +2751,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_trace"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60a5983a6c65df871d18b8846ce6231d775be0e04c5cae96ed463ce36e80c27e"
+checksum = "9e0830ddc3a2eb5467dbc8056c87ed64df917642266cb2df4737eb97f38d01b7"
 dependencies = [
  "chrono",
  "derive_more 0.99.20",
@@ -2751,9 +2769,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_types"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1761c6f13886fa2fe50273a61ca77db83c5d94c79ceba6f7c79830d64e099830"
+checksum = "3b3ce0dbeb35478ff98d2f51a39048a7e8202a0935a5fddfb25d3566afea415a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2803,12 +2821,12 @@ dependencies = [
 
 [[package]]
 name = "holochain_util"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66bbb7b006793834b727d0c6ca19ca5c4677e0bea69e0e61192d6ae103b609c9"
+checksum = "98aef3178066cea48acb213bb267b859545ae442d3fdbfc45a5276c864121750"
 dependencies = [
  "backtrace",
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "colored",
  "dunce",
  "futures",
@@ -2845,9 +2863,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_websocket"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a875fca5ba65482687cda65103eba005410b05c550947f72fe2975e112cca8a5"
+checksum = "001e16725c7d5f073cb090b65d60bf086243b1f6114d7cd24ea2482686a953ba"
 dependencies = [
  "async-trait",
  "futures",
@@ -2880,9 +2898,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_zome_types"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c87a61303ec8665a53ed34595c163070c709da9ec6c72acdd5d647c749df278"
+checksum = "9e036d059008d6c5fa53d17c931c9402415be45c11e19e4978038c9280026d4b"
 dependencies = [
  "derive_builder",
  "derive_more 0.99.20",
@@ -2895,7 +2913,7 @@ dependencies = [
  "kitsune_p2p_dht",
  "kitsune_p2p_timestamp",
  "nanoid",
- "num_enum 0.7.3",
+ "num_enum 0.7.4",
  "rusqlite",
  "serde",
  "serde_bytes",
@@ -2924,7 +2942,7 @@ dependencies = [
  "bson",
  "bytes",
  "chrono",
- "clap 4.5.39",
+ "clap 4.5.41",
  "data-encoding",
  "db_utils",
  "dotenv",
@@ -3086,14 +3104,14 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.3.26",
+ "h2 0.3.27",
  "http 0.2.12",
  "http-body 0.4.6",
  "httparse",
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -3109,7 +3127,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "h2 0.4.10",
+ "h2 0.4.11",
  "http 1.3.1",
  "http-body 1.0.1",
  "httparse",
@@ -3139,26 +3157,26 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.6"
+version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03a01595e11bdcec50946522c32dde3fc6914743000a68b93000965f2f02406d"
+checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
  "http 1.3.1",
  "hyper 1.6.0",
  "hyper-util",
- "rustls 0.23.27",
+ "rustls 0.23.29",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.2",
  "tower-service",
- "webpki-roots 1.0.0",
+ "webpki-roots 1.0.2",
 ]
 
 [[package]]
 name = "hyper-util"
-version = "0.1.13"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1c293b6b3d21eca78250dc7dbebd6b9210ec5530e038cbfe0661b5c47ab06e8"
+checksum = "8d9b05277c7e8da2c93a568989bb6207bef0112e8d17df7a6eda4a3cf143bc5e"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -3172,7 +3190,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.0",
  "tokio",
  "tower-service",
  "tracing",
@@ -3345,12 +3363,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.9.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.3",
+ "hashbrown 0.15.4",
  "serde",
 ]
 
@@ -3361,12 +3379,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "232929e1d75fe899576a3d5c7416ad0d88dbfbb3c3d6aa00873a7408a50ddb88"
 dependencies = [
  "ahash",
- "clap 4.5.39",
+ "clap 4.5.41",
  "crossbeam-channel",
  "crossbeam-utils",
  "dashmap 6.1.0",
  "env_logger",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "is-terminal",
  "itoa",
  "log",
@@ -3421,6 +3439,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-uring"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d93587f37623a1a17d94ef2bc9ada592f5465fe7732084ab7beefabe5c77c0c4"
+dependencies = [
+ "bitflags 2.9.1",
+ "cfg-if 1.0.1",
+ "libc",
+]
+
+[[package]]
 name = "ioctl-rs"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3435,7 +3464,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b58db92f96b720de98181bbbe63c831e87005ab460c1bf306eb2622b4707997f"
 dependencies = [
- "socket2",
+ "socket2 0.5.10",
  "widestring",
  "windows-sys 0.48.0",
  "winreg 0.50.0",
@@ -3463,7 +3492,7 @@ version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
 dependencies = [
- "hermit-abi 0.5.1",
+ "hermit-abi 0.5.2",
  "libc",
  "windows-sys 0.59.0",
 ]
@@ -3500,9 +3529,9 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "jiff"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a194df1107f33c79f4f93d02c80798520551949d59dfad22b6157048a88cca93"
+checksum = "be1f93b8b1eb69c77f24bbb0afdf66f54b632ee39af40ca21c4365a1d7347e49"
 dependencies = [
  "jiff-static",
  "log",
@@ -3513,13 +3542,13 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c6e1db7ed32c6c71b759497fae34bf7933636f75a251b9e736555da426f6442"
+checksum = "03343451ff899767262ec32146f6d559dd759fdadf42ff0e227c7c48f72594b4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -3570,9 +3599,9 @@ dependencies = [
 
 [[package]]
 name = "kitsune_p2p_bin_data"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "091ef68b40df5c0a131b4df415d09b9d8e20fbdb567e39722f8d49ed18648a41"
+checksum = "ebd05d46cee545ff5c428f3a1e4ec51599f2a642596a571ba8778116981dcfef"
 dependencies = [
  "base64 0.22.1",
  "derive_more 0.99.20",
@@ -3585,9 +3614,9 @@ dependencies = [
 
 [[package]]
 name = "kitsune_p2p_block"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2611a95679fa50e6726855a164056887b3070d753c7d1f821a0ac67669eff36e"
+checksum = "15accdae08b64e2a0df414593a898e223ddc8a2355ab15ee50e4857ac9786afd"
 dependencies = [
  "kitsune_p2p_bin_data",
  "kitsune_p2p_timestamp",
@@ -3596,9 +3625,9 @@ dependencies = [
 
 [[package]]
 name = "kitsune_p2p_dht"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f03ce38b58f1afa9bb549801b370a5e8d3c4f204d3dd5b9d6da049fb29c1529"
+checksum = "6ca91b5986504c4e2dfabd44c6db567b67ac2b3501e2224e687fab18e0db4a8a"
 dependencies = [
  "arbitrary",
  "colored",
@@ -3620,9 +3649,9 @@ dependencies = [
 
 [[package]]
 name = "kitsune_p2p_dht_arc"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773fe8c32cce3c77c030e1130030e82051992a585b1e5599c1a8a4684e01cae7"
+checksum = "dda83debad8a4999db24ff536e6d32c831a9e338e616f729bd0d7d4cba69c57b"
 dependencies = [
  "arbitrary",
  "derive_more 0.99.20",
@@ -3638,9 +3667,9 @@ dependencies = [
 
 [[package]]
 name = "kitsune_p2p_timestamp"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb6ef7e26d3c9d1d547b75ec0c53da00b78bf1ceaace2e4f99634b240ae9ef2"
+checksum = "0ec86dcf539578117fa59c69b096e655b323e114fe22bfb58505931a06ec7a68"
 dependencies = [
  "arbitrary",
  "chrono",
@@ -3654,9 +3683,9 @@ dependencies = [
 
 [[package]]
 name = "kitsune_p2p_types"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "316f46443888901530f5362cffe34ad0c7f5aa7e809cb623a0736c2c44a5d280"
+checksum = "f02858da056cb8576b1c9e52f2ff530e5c6b516fd2d975112bbc1731c410b1f5"
 dependencies = [
  "base64 0.22.1",
  "derive_more 0.99.20",
@@ -3717,7 +3746,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "tokio",
- "toml 0.8.22",
+ "toml 0.8.23",
  "tracing",
  "url",
  "winapi",
@@ -3744,9 +3773,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.172"
+version = "0.2.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
+checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
 name = "libflate"
@@ -3778,8 +3807,8 @@ version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
- "cfg-if 1.0.0",
- "windows-targets 0.53.0",
+ "cfg-if 1.0.1",
+ "windows-targets 0.53.2",
 ]
 
 [[package]]
@@ -3790,9 +3819,9 @@ checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
 name = "libredox"
-version = "0.1.3"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
+checksum = "4488594b9328dee448adb906d8b126d9b7deb7cf5c22161ee591610bb1be83c0"
 dependencies = [
  "bitflags 2.9.1",
  "libc",
@@ -3829,9 +3858,9 @@ dependencies = [
 
 [[package]]
 name = "libz-rs-sys"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6489ca9bd760fe9642d7644e827b0c9add07df89857b0416ee15c1cc1a3b8c5a"
+checksum = "172a788537a2221661b480fee8dc5f96c580eb34fa88764d3205dc356c7e4221"
 dependencies = [
  "zlib-rs",
 ]
@@ -3899,7 +3928,7 @@ version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
 dependencies = [
- "hashbrown 0.15.3",
+ "hashbrown 0.15.4",
 ]
 
 [[package]]
@@ -3946,7 +3975,7 @@ dependencies = [
  "macro_magic_core",
  "macro_magic_macros",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -3960,7 +3989,7 @@ dependencies = [
  "macro_magic_core_macros",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -3971,7 +4000,7 @@ checksum = "b02abfe41815b5bd98dbd4260173db2c116dda171dc0fe7838cb206333b83308"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -3982,7 +4011,7 @@ checksum = "73ea28ee64b88876bf45277ed9a5817c1817df061a74f2b988971a12570e5869"
 dependencies = [
  "macro_magic_core",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -4022,15 +4051,15 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "digest",
 ]
 
 [[package]]
 name = "memchr"
-version = "2.7.4"
+version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
 name = "mime"
@@ -4062,9 +4091,9 @@ checksum = "e856fdd13623a2f5f2f54676a4ee49502a96a80ef4a62bcedd23d52427c44d43"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be647b768db090acb35d5ec5db2b0e1f1de11133ca123b9eacf5137868f892a"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
 ]
@@ -4077,7 +4106,7 @@ checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
 dependencies = [
  "libc",
  "log",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.59.0",
 ]
 
@@ -4101,7 +4130,7 @@ dependencies = [
  "mongodb",
  "nats-jwt",
  "nats_utils",
- "rand 0.9.1",
+ "rand 0.9.2",
  "sea-strum_macros",
  "semver",
  "serde",
@@ -4118,9 +4147,9 @@ dependencies = [
 
 [[package]]
 name = "mongodb"
-version = "3.2.3"
+version = "3.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdf4261933e5113914caec01c4bb16a7502bdaa9cf80fd87191765e7d9ff16b2"
+checksum = "d0f8c69f13acf07eae386a2974f48ffd9187ea2aba8defbea9aa34e7e272c5f3"
 dependencies = [
  "async-trait",
  "base64 0.13.1",
@@ -4150,9 +4179,9 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_with",
- "sha-1",
+ "sha1",
  "sha2",
- "socket2",
+ "socket2 0.5.10",
  "stringprep",
  "strsim 0.11.1",
  "take_mut",
@@ -4167,21 +4196,21 @@ dependencies = [
 
 [[package]]
 name = "mongodb-internal-macros"
-version = "3.2.3"
+version = "3.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "619176c99deef0d50be51ce3193e9efd6a56ab0f4e6a38d5fd614880d148c7ae"
+checksum = "b9202de265a3a8bbb43f9fe56db27c93137d4f9fb04c093f47e9c7de0c61ac7d"
 dependencies = [
  "macro_magic",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
 name = "mr_bundle"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2989543f08bdd2758481f9e1e28e2d13c22746de9eb650d1824092fada279820"
+checksum = "5a06d77acc88f9386752e294a2561948f54565ca20dc6cd74262d096415f0c29"
 dependencies = [
  "derive_more 0.99.20",
  "flate2",
@@ -4266,7 +4295,7 @@ dependencies = [
  "bson",
  "bytes",
  "chrono",
- "clap 4.5.39",
+ "clap 4.5.41",
  "derive_more 1.0.0",
  "dotenv",
  "educe",
@@ -4277,7 +4306,7 @@ dependencies = [
  "mock_utils",
  "mongodb",
  "nats-jwt",
- "rand 0.9.1",
+ "rand 0.9.2",
  "reqwest",
  "sea-strum_macros",
  "semver",
@@ -4298,11 +4327,11 @@ name = "netdiag"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap 4.5.39",
+ "clap 4.5.41",
  "env_logger",
  "log",
  "rustdns",
- "rustls 0.23.27",
+ "rustls 0.23.29",
  "serde",
  "serde_yaml",
  "thiserror 2.0.12",
@@ -4444,7 +4473,7 @@ version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
 dependencies = [
- "hermit-abi 0.5.1",
+ "hermit-abi 0.5.2",
  "libc",
 ]
 
@@ -4460,11 +4489,12 @@ dependencies = [
 
 [[package]]
 name = "num_enum"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e613fc340b2220f734a8595782c551f1250e969d87d3be1ae0579e8d4065179"
+checksum = "a973b4e44ce6cad84ce69d797acf9a044532e4184c4f267913d1b546a0727b7a"
 dependencies = [
- "num_enum_derive 0.7.3",
+ "num_enum_derive 0.7.4",
+ "rustversion",
 ]
 
 [[package]]
@@ -4481,14 +4511,14 @@ dependencies = [
 
 [[package]]
 name = "num_enum_derive"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
+checksum = "77e878c846a8abae00dd069496dbe8751b16ac1c3d6bd2a7283a938e8228f90d"
 dependencies = [
  "proc-macro-crate 3.3.0",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -4562,7 +4592,7 @@ dependencies = [
  "bson",
  "bytes",
  "chrono",
- "clap 4.5.39",
+ "clap 4.5.41",
  "db_utils",
  "dotenv",
  "env_logger",
@@ -4623,7 +4653,7 @@ version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "libc",
  "redox_syscall",
  "smallvec",
@@ -4699,9 +4729,9 @@ checksum = "d8a5fe545d2e2e7b6ff42ca8dd6c1750ad41c311d41a736481d10a010078c88e"
 
 [[package]]
 name = "pest"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "198db74531d58c70a361c42201efde7e2591e976d518caf7662a47dc5720e7b6"
+checksum = "1db05f56d34358a8b1066f67cbb203ee3e7ed2ba674a6263a1d5ec6db2204323"
 dependencies = [
  "memchr",
  "thiserror 2.0.12",
@@ -4732,9 +4762,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d725d9cfd79e87dccc9341a2ef39d1b6f6353d68c4b33c177febbe1a402c97c5"
+checksum = "bb056d9e8ea77922845ec74a1c4e8fb17e7c218cc4fc11a15c5d25e189aa40bc"
 dependencies = [
  "pest",
  "pest_generator",
@@ -4742,24 +4772,23 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db7d01726be8ab66ab32f9df467ae8b1148906685bbe75c82d1e65d7f5b3f841"
+checksum = "87e404e638f781eb3202dc82db6760c8ae8a1eeef7fb3fa8264b2ef280504966"
 dependencies = [
  "pest",
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
 name = "pest_meta"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f9f832470494906d1fca5329f8ab5791cc60beb230c74815dff541cbd2b5ca0"
+checksum = "edd1101f170f5903fde0914f899bb503d9ff5271d7ba76bbb70bea63690cc0d5"
 dependencies = [
- "once_cell",
  "pest",
  "sha2",
 ]
@@ -4781,7 +4810,7 @@ checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -4814,9 +4843,9 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "portable-atomic"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e"
+checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
 
 [[package]]
 name = "portable-atomic-util"
@@ -4890,12 +4919,12 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.33"
+version = "0.2.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dee91521343f4c5c6a63edd65e54f31f5c92fe8978c40a4282f8372194c6a7d"
+checksum = "ff24dfcda44452b9816fff4cd4227e1bb73ff5a2f1bc1105aa92fb8565ce44d2"
 dependencies = [
  "proc-macro2",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -4985,17 +5014,17 @@ dependencies = [
 
 [[package]]
 name = "proptest"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14cae93065090804185d3b75f0bf93b8eeda30c7a9b4a33d3bdb3988d6229e50"
+checksum = "6fcdab19deb5195a31cf7726a210015ff1496ba1464fd42cb4f537b8b01b471f"
 dependencies = [
  "bit-set 0.8.0",
  "bit-vec 0.8.0",
  "bitflags 2.9.1",
  "lazy_static",
  "num-traits",
- "rand 0.8.5",
- "rand_chacha 0.3.1",
+ "rand 0.9.2",
+ "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax 0.8.5",
  "rusty-fork",
@@ -5005,13 +5034,13 @@ dependencies = [
 
 [[package]]
 name = "proptest-derive"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ee1c9ac207483d5e7db4940700de86a9aae46ef90c48b57f99fe7edb8345e49"
+checksum = "095a99f75c69734802359b682be8daaf8980296731f6470434ea2c652af1dd30"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -5041,8 +5070,8 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash 2.1.1",
- "rustls 0.23.27",
- "socket2",
+ "rustls 0.23.29",
+ "socket2 0.5.10",
  "thiserror 2.0.12",
  "tokio",
  "tracing",
@@ -5058,10 +5087,10 @@ dependencies = [
  "bytes",
  "getrandom 0.3.3",
  "lru-slab",
- "rand 0.9.1",
+ "rand 0.9.2",
  "ring 0.17.14",
  "rustc-hash 2.1.1",
- "rustls 0.23.27",
+ "rustls 0.23.29",
  "rustls-pki-types",
  "slab",
  "thiserror 2.0.12",
@@ -5072,14 +5101,14 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.12"
+version = "0.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee4e529991f949c5e25755532370b8af5d114acae52326361d68d47af64aa842"
+checksum = "fcebb1209ee276352ef14ff8732e24cc2b02bbac986cd74a4c81bcb2f9881970"
 dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.59.0",
 ]
@@ -5095,9 +5124,9 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
-version = "5.2.0"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "r2d2"
@@ -5142,9 +5171,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
@@ -5228,11 +5257,11 @@ dependencies = [
 
 [[package]]
 name = "rand_xorshift"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
 dependencies = [
- "rand_core 0.6.4",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -5288,10 +5317,10 @@ dependencies = [
  "num-bigint",
  "percent-encoding",
  "pin-project-lite",
- "rustls 0.23.27",
+ "rustls 0.23.29",
  "rustls-native-certs 0.8.1",
  "ryu",
- "socket2",
+ "socket2 0.5.10",
  "tokio",
  "tokio-rustls 0.26.2",
  "tokio-util",
@@ -5307,18 +5336,18 @@ checksum = "438a4e5f8e9aa246d6f3666d6978441bf1b37d5f417b50c4dd220be09f5fcc17"
 dependencies = [
  "arc-swap",
  "bytes",
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "combine",
  "futures-util",
  "itoa",
  "num-bigint",
  "percent-encoding",
  "pin-project-lite",
- "rustls 0.23.27",
+ "rustls 0.23.29",
  "rustls-native-certs 0.8.1",
  "ryu",
  "sha1_smol",
- "socket2",
+ "socket2 0.5.10",
  "tokio",
  "tokio-rustls 0.26.2",
  "tokio-util",
@@ -5328,11 +5357,31 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.12"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "928fca9cf2aa042393a8325b9ead81d2f0df4cb12e1e24cef072922ccd99c5af"
+checksum = "7e8af0dde094006011e6a740d4879319439489813bd0bcdc7d821beaeeff48ec"
 dependencies = [
  "bitflags 2.9.1",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a0ae411dbe946a674d89546582cea4ba2bb8defac896622d6496f14c23ba5cf"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1165225c21bff1f3bbce98f5a1f889949bc902d3575308cc7b0de30b4f6d27c7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -5387,9 +5436,9 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "reqwest"
-version = "0.12.19"
+version = "0.12.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2f8e5513d63f2e5b386eb5106dc67eaf3f84e95258e210489136b8b92ad6119"
+checksum = "cbc931937e6ca3a06e3b6c0aa7841849b160a90351d6ab467a8b9b9959767531"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -5402,15 +5451,12 @@ dependencies = [
  "hyper 1.6.0",
  "hyper-rustls",
  "hyper-util",
- "ipnet",
  "js-sys",
  "log",
- "mime",
- "once_cell",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.27",
+ "rustls 0.23.29",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -5425,7 +5471,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots 1.0.0",
+ "webpki-roots 1.0.2",
 ]
 
 [[package]]
@@ -5436,9 +5482,9 @@ checksum = "95325155c684b1c89f7765e30bc1c42e4a6da51ca513615660cb8a62ef9a88e3"
 
 [[package]]
 name = "rgb"
-version = "0.8.50"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57397d16646700483b67d2dd6511d79318f9d057fdbd21a4066aeac8b41d310a"
+checksum = "0c6a884d2998352bb4daf0183589aec883f16a6da1f4dde84d8e2e9a5409a1ce"
 dependencies = [
  "bytemuck",
 ]
@@ -5465,7 +5511,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "getrandom 0.2.16",
  "libc",
  "untrusted 0.9.0",
@@ -5579,7 +5625,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rust-embed-utils",
- "syn 2.0.101",
+ "syn 2.0.104",
  "walkdir",
 ]
 
@@ -5595,20 +5641,19 @@ dependencies = [
 
 [[package]]
 name = "rust-ini"
-version = "0.21.1"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e310ef0e1b6eeb79169a1171daf9abcb87a2e17c03bee2c4bb100b55c75409f"
+checksum = "e7295b7ce3bf4806b419dc3420745998b447178b7005e2011947b38fc5aa6791"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "ordered-multimap",
- "trim-in-place",
 ]
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.24"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
+checksum = "989e6739f80c4ad5b13e0fd7fe89531180375b18520cc8c82080e4dc4035b84f"
 
 [[package]]
 name = "rustc-hash"
@@ -5690,15 +5735,15 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
+checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
 dependencies = [
  "bitflags 2.9.1",
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5728,16 +5773,16 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.27"
+version = "0.23.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "730944ca083c1c233a75c09f199e973ca499344a2b7ba9e755c457e86fb4a321"
+checksum = "2491382039b29b9b11ff08b76ff6c97cf287671dbb74f0be44bda389fffe9bd1"
 dependencies = [
  "aws-lc-rs",
  "log",
  "once_cell",
  "ring 0.17.14",
  "rustls-pki-types",
- "rustls-webpki 0.103.3",
+ "rustls-webpki 0.103.4",
  "subtle",
  "zeroize",
 ]
@@ -5817,9 +5862,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.3"
+version = "0.103.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4a72fe2bcf7a6ac6fd7d0b9e5cb68aeb7d4c0a0271730218b3e92d43b4eb435"
+checksum = "0a17884ae0c1b773f1ccd2bd4a8c72f16da897310a98b0e84bf349ad5ead92fc"
 dependencies = [
  "aws-lc-rs",
  "ring 0.17.14",
@@ -5885,6 +5930,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3cbc66816425a074528352f5789333ecff06ca41b36b0b0efdfbb29edc391a19"
 dependencies = [
  "parking_lot",
+]
+
+[[package]]
+name = "schemars"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82d20c4491bc164fa2f6c5d44565947a52ad80b9505d8e36f8d54c27c739fcd0"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -6003,16 +6072,16 @@ checksum = "500cbc0ebeb6f46627f50f3f5811ccf6bf00643be300b4c3eabc0ef55dc5b5ba"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.140"
+version = "1.0.141"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
+checksum = "30b9eff21ebe718216c6ec64e1d9ac57087aad11efc64e32002bce4a0d4c03d3"
 dependencies = [
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "itoa",
  "memchr",
  "ryu",
@@ -6055,14 +6124,23 @@ checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.8"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40734c41988f7306bb04f0ecf60ec0f3f1caa34290e4e8ea471dcd3346483b83"
 dependencies = [
  "serde",
 ]
@@ -6081,15 +6159,17 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.12.0"
+version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6b6f7f2fcb69f747921f79f3926bd1e203fce4fef62c268dd3abfb6d86029aa"
+checksum = "f2c45cd61fefa9db6f254525d46e392b852e0e61d9a1fd36e5bd183450a556d5"
 dependencies = [
  "base64 0.22.1",
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
+ "schemars 0.9.0",
+ "schemars 1.0.4",
  "serde",
  "serde_derive",
  "serde_json",
@@ -6099,14 +6179,14 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.12.0"
+version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d00caa5193a3c8362ac2b73be6b9e768aa5a4b2f721d8f4b339600c3cb51f8e"
+checksum = "de90945e6565ce0d9a25098082ed4ee4002e047cb59892c318d66821e14bb30f"
 dependencies = [
  "darling 0.20.11",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -6115,7 +6195,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "itoa",
  "ryu",
  "serde",
@@ -6186,7 +6266,7 @@ checksum = "91d129178576168c589c9ec973feedf7d3126c01ac2bf08795109aa35b69fb8f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -6195,7 +6275,7 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f5058ada175748e33390e40e872bd0fe59a19f265d0158daa551c5a88a76009c"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "cpufeatures",
  "digest",
 ]
@@ -6206,7 +6286,7 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "cpufeatures",
  "digest",
 ]
@@ -6223,7 +6303,7 @@ version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "cpufeatures",
  "digest",
 ]
@@ -6330,18 +6410,15 @@ dependencies = [
 
 [[package]]
 name = "slab"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
-dependencies = [
- "autocfg",
-]
+checksum = "04dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d"
 
 [[package]]
 name = "smallvec"
-version = "1.15.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
@@ -6351,6 +6428,16 @@ checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "socket2"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6498,11 +6585,11 @@ checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
 
 [[package]]
 name = "strum"
-version = "0.27.1"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f64def088c51c9510a8579e3c5d67c65349dcf755e5479ad3d010aa6454e2c32"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
 dependencies = [
- "strum_macros 0.27.1",
+ "strum_macros 0.27.2",
 ]
 
 [[package]]
@@ -6540,20 +6627,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
 name = "strum_macros"
-version = "0.27.1"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c77a8c5abcaf0f9ce05d62342b7d298c346515365c36b673df4ebe3ced01fde8"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "rustversion",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -6584,9 +6670,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.101"
+version = "2.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
+checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6622,7 +6708,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -6631,7 +6717,7 @@ version = "0.29.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd727fc423c2060f6c92d9534cef765c65a6ed3f428a03d7def74a8c4348e666"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "core-foundation-sys",
  "libc",
  "ntapi",
@@ -6686,7 +6772,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.3.3",
  "once_cell",
- "rustix 1.0.7",
+ "rustix 1.0.8",
  "windows-sys 0.59.0",
 ]
 
@@ -6773,7 +6859,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -6784,17 +6870,16 @@ checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
 name = "thread_local"
-version = "1.1.8"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
- "cfg-if 1.0.0",
- "once_cell",
+ "cfg-if 1.0.1",
 ]
 
 [[package]]
@@ -6864,18 +6949,20 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.45.1"
+version = "1.46.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75ef51a33ef1da925cea3e4eb122833cb377c61439ca401b770f54902b806779"
+checksum = "0cc3a2344dafbe23a245241fe8b09735b521110d30fcefbbd5feb1797ca35d17"
 dependencies = [
  "backtrace",
  "bytes",
+ "io-uring",
  "libc",
  "mio",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "slab",
+ "socket2 0.5.10",
  "tokio-macros",
  "windows-sys 0.52.0",
 ]
@@ -6888,7 +6975,7 @@ checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -6929,7 +7016,7 @@ version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
 dependencies = [
- "rustls 0.23.27",
+ "rustls 0.23.29",
  "tokio",
 ]
 
@@ -6991,44 +7078,75 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.22"
+version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05ae329d1f08c4d17a59bed7ff5b5a769d062e64a62d34a3261b219e62cd5aae"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
- "serde_spanned",
- "toml_datetime",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
  "toml_edit",
 ]
 
 [[package]]
-name = "toml_datetime"
-version = "0.6.9"
+name = "toml"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3da5db5a963e24bc68be8b17b6fa82814bb22ee8660f192bb182771d498f09a3"
+checksum = "ed0aee96c12fa71097902e0bb061a5e1ebd766a6636bb605ba401c45c1650eac"
+dependencies = [
+ "serde",
+ "serde_spanned 1.0.0",
+ "toml_datetime 0.7.0",
+ "toml_parser",
+ "winnow",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bade1c3e902f58d73d3f294cd7f20391c1cb2fbcb643b73566bc773971df91e3"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.22.26"
+version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "310068873db2c5b3e7659d2cc35d21855dbafa50d1ce336397c666e3cb08137e"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "serde",
- "serde_spanned",
- "toml_datetime",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
  "toml_write",
  "winnow",
 ]
 
 [[package]]
-name = "toml_write"
-version = "0.1.1"
+name = "toml_parser"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfb942dfe1d8e29a7ee7fcbde5bd2b9a25fb89aa70caea2eba3bee836ff41076"
+checksum = "97200572db069e74c512a14117b296ba0a80a30123fbbb5aa1f4a348f639ca30"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "touch"
@@ -7057,9 +7175,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.5"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cc2d9e086a412a451384326f521c8123a99a466b329941a9403696bff9b0da2"
+checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
 dependencies = [
  "bitflags 2.9.1",
  "bytes",
@@ -7099,20 +7217,20 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.28"
+version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
+checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.33"
+version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
+checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
 dependencies = [
  "once_cell",
  "valuable",
@@ -7188,12 +7306,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683ba5022fe6dbd7133cad150478ccf51bdb6d861515181e5fc6b4323d4fa424"
 
 [[package]]
-name = "trim-in-place"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "343e926fc669bc8cde4fa3129ab681c63671bae288b1f1081ceee6d9d37904fc"
-
-[[package]]
 name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7201,11 +7313,10 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tryhard"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c9f0a709784e86923586cff0d872dba54cd2d2e116b3bc57587d15737cfce9d"
+checksum = "9fe58ebd5edd976e0fe0f8a14d2a04b7c81ef153ea9a54eebc42e67c2c23b4e5"
 dependencies = [
- "futures",
  "pin-project-lite",
  "tokio",
 ]
@@ -7402,11 +7513,11 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "utoipa"
-version = "5.3.1"
+version = "5.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "435c6f69ef38c9017b4b4eea965dfb91e71e53d869e896db40d1cf2441dd75c0"
+checksum = "2fcc29c80c21c31608227e0912b2d7fddba57ad76b606890627ba8ee7964e993"
 dependencies = [
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "serde",
  "serde_json",
  "utoipa-gen",
@@ -7414,14 +7525,14 @@ dependencies = [
 
 [[package]]
 name = "utoipa-gen"
-version = "5.3.1"
+version = "5.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a77d306bc75294fd52f3e99b13ece67c02c1a2789190a6f31d32f736624326f7"
+checksum = "6d79d08d92ab8af4c5e8a6da20c47ae3f61a0f1dabc1997cdf2d082b757ca08b"
 dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -7478,7 +7589,7 @@ checksum = "3cf4199d1e5d15ddd86a694e4d0dffa9c323ce759fea589f00fef9d81cc1931d"
 dependencies = [
  "getrandom 0.3.3",
  "js-sys",
- "rand 0.9.1",
+ "rand 0.9.2",
  "serde",
  "wasm-bindgen",
 ]
@@ -7543,9 +7654,9 @@ checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
+version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasi"
@@ -7568,7 +7679,7 @@ version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "once_cell",
  "rustversion",
  "wasm-bindgen-macro",
@@ -7584,7 +7695,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
  "wasm-bindgen-shared",
 ]
 
@@ -7594,7 +7705,7 @@ version = "0.4.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "js-sys",
  "once_cell",
  "wasm-bindgen",
@@ -7619,7 +7730,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -7684,14 +7795,14 @@ version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
 dependencies = [
- "webpki-roots 1.0.0",
+ "webpki-roots 1.0.2",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.0"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2853738d1cc4f2da3a225c18ec6c3721abb31961096e9dbf5ab35fa88b19cfdb"
+checksum = "7e8983c3ab33d6fb807cfcdad2491c4ea8cbc8ed839181c7dfd9c67c83e261b2"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -7721,9 +7832,9 @@ dependencies = [
 
 [[package]]
 name = "wide"
-version = "0.7.32"
+version = "0.7.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41b5576b9a81633f3e8df296ce0063042a73507636cbe956c61133dd7034ab22"
+checksum = "0ce5da8ecb62bcd8ec8b7ea19f69a51275e91299be594ea5cc6ef7819e16cd03"
 dependencies = [
  "bytemuck",
  "safe_arch",
@@ -7831,7 +7942,7 @@ checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -7842,7 +7953,7 @@ checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -7864,7 +7975,7 @@ checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -7875,14 +7986,14 @@ checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
 name = "windows-link"
-version = "0.1.1"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
 name = "windows-result"
@@ -7939,6 +8050,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.2",
+]
+
+[[package]]
 name = "windows-targets"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7971,9 +8091,9 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.53.0"
+version = "0.53.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1e4c7e8ceaaf9cb7d7507c974735728ab453b67ef8f18febdd7c11fe59dca8b"
+checksum = "c66f69fcc9ce11da9966ddb31a40968cad001c5bedeb5c2b82ede4253ab48aef"
 dependencies = [
  "windows_aarch64_gnullvm 0.53.0",
  "windows_aarch64_msvc 0.53.0",
@@ -8125,9 +8245,9 @@ checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winnow"
-version = "0.7.10"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06928c8748d81b05c9be96aad92e1b6ff01833332f281e8cfca3be4b35fc9ec"
+checksum = "f3edebf492c8125044983378ecb5766203ad3b4c2f7a922bd7dd207f6d443e95"
 dependencies = [
  "memchr",
 ]
@@ -8138,7 +8258,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76a1a57ff50e9b408431e8f97d5456f2807f8eb2a2cd79b06068fc87f8ecf189"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "winapi",
 ]
 
@@ -8148,7 +8268,7 @@ version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "windows-sys 0.48.0",
 ]
 
@@ -8229,19 +8349,19 @@ dependencies = [
 
 [[package]]
 name = "xattr"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d65cbf2f12c15564212d48f4e3dfb87923d25d611f2aed18f4cb23f0413d89e"
+checksum = "af3a19837351dc82ba89f8a125e22a3c475f05aba604acc023d62b2739ae2909"
 dependencies = [
  "libc",
- "rustix 1.0.7",
+ "rustix 1.0.8",
 ]
 
 [[package]]
 name = "yaml-rust2"
-version = "0.10.2"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18b783b2c2789414f8bb84ca3318fc9c2d7e7be1c22907d37839a58dedb369d3"
+checksum = "4ce2a4ff45552406d02501cea6c18d8a7e50228e7736a872951fe2fe75c91be7"
 dependencies = [
  "arraydeque",
  "encoding_rs",
@@ -8283,28 +8403,28 @@ checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
  "synstructure 0.13.2",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.25"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1702d9583232ddb9174e01bb7c15a2ab8fb1bc6f227aa1233858c351a3ba0cb"
+checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.25"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
+checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -8324,7 +8444,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
  "synstructure 0.13.2",
 ]
 
@@ -8364,7 +8484,7 @@ checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -8378,7 +8498,7 @@ dependencies = [
  "crossbeam-utils",
  "displaydoc",
  "flate2",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "memchr",
  "thiserror 2.0.12",
  "zopfli",
@@ -8393,16 +8513,16 @@ dependencies = [
  "arbitrary",
  "crc32fast",
  "flate2",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "memchr",
  "zopfli",
 ]
 
 [[package]]
 name = "zlib-rs"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "868b928d7949e09af2f6086dfc1e01936064cc7a819253bce650d4e2a2d63ba8"
+checksum = "626bd9fa9734751fc50d6060752170984d7053f5a39061f524cda68023d4db8a"
 
 [[package]]
 name = "zopfli"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2932,6 +2932,7 @@ dependencies = [
  "env_logger",
  "futures",
  "hpos-hal",
+ "hpos_updates",
  "inventory",
  "jsonwebtoken",
  "log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2976,6 +2976,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "hpos_updates"
+version = "0.0.1"
+dependencies = [
+ "anyhow",
+ "async-nats",
+ "base32",
+ "bson",
+ "bytes",
+ "ctor",
+ "data-encoding",
+ "db_utils",
+ "dotenv",
+ "env_logger",
+ "hpos-hal",
+ "jsonwebtoken",
+ "log",
+ "mock_utils",
+ "mongodb",
+ "nats-jwt",
+ "nats_utils",
+ "nkeys",
+ "serde",
+ "serde_json",
+ "serial_test",
+ "sha2",
+ "tempfile",
+ "tokio",
+]
+
+[[package]]
 name = "http"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
   "rust/clients/orchestrator",
   "rust/services/inventory",
   "rust/services/workload",
+  "rust/services/hpos_updates",
   "rust/util_libs/nats",
   "rust/util_libs/db",
   "rust/util_libs/mocks",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ nats_utils = { path = "rust/util_libs/nats" }
 db_utils = { path = "rust/util_libs/db" }
 orchestrator = { path = "rust/clients/orchestrator" }
 host_agent = { path = "rust/clients/host_agent" }
+hpos_updates = { path = "rust/services/hpos_updates" }
 inventory = { path = "rust/services/inventory" }
 workload = { path = "rust/services/workload" }
 ham = { path = "rust/ham" }

--- a/nix/packages/rust-workspace.nix
+++ b/nix/packages/rust-workspace.nix
@@ -70,6 +70,7 @@ craneLib.buildPackage (
                 (craneLib.fileset.commonCargoSources ../../rust/util_libs/db)
                 (craneLib.fileset.commonCargoSources ../../rust/hpos-hal)
                 (craneLib.fileset.commonCargoSources ../../rust/services/workload)
+                (craneLib.fileset.commonCargoSources ../../rust/services/hpos_updates)
                 (craneLib.fileset.commonCargoSources ../../rust/services/inventory)
                 (craneLib.fileset.commonCargoSources ../../rust/ham)
                 (craneLib.fileset.commonCargoSources ../../rust/netdiag)

--- a/rust/clients/host_agent/Cargo.toml
+++ b/rust/clients/host_agent/Cargo.toml
@@ -23,6 +23,7 @@ netdiag = { workspace = true }
 hpos-hal = { workspace = true }
 nats_utils = { workspace = true }
 workload = { workspace = true }
+hpos_updates = { workspace = true }
 inventory = { workspace = true }
 db_utils = { workspace = true }
 url = { version = "2", features = ["serde"] }

--- a/rust/clients/host_agent/src/agent_cli.rs
+++ b/rust/clients/host_agent/src/agent_cli.rs
@@ -210,11 +210,11 @@ pub enum RemoteCommands {
         request: HcHttpGwRequest,
     },
 
-    // /// Remotely trigger a NixOS update on a specified host.
-    // HostNixosUpdate {
-    //     #[arg(short, long)]
-    //     device_id: String,
-    //     #[arg(short, long, default_value = "towards-allograph")]
-    //     channel: String,
-    // },
+    /// Remotely trigger a NixOS update on a specified host.
+    HostNixosUpdate {
+        #[arg(short, long)]
+        device_id: String,
+        #[arg(short, long, default_value = "towards-allograph")]
+        channel: String,
+    },
 }

--- a/rust/clients/host_agent/src/agent_cli.rs
+++ b/rust/clients/host_agent/src/agent_cli.rs
@@ -210,11 +210,11 @@ pub enum RemoteCommands {
         request: HcHttpGwRequest,
     },
 
-    /// Remotely trigger a NixOS update on a specified host.
-    HostNixosUpdate {
-        #[arg(short, long)]
-        device_id: String,
-        #[arg(short, long, default_value = "towards-allograph")]
-        channel: String,
-    },
+    // /// Remotely trigger a NixOS update on a specified host.
+    // HostNixosUpdate {
+    //     #[arg(short, long)]
+    //     device_id: String,
+    //     #[arg(short, long, default_value = "towards-allograph")]
+    //     channel: String,
+    // },
 }

--- a/rust/clients/host_agent/src/agent_cli.rs
+++ b/rust/clients/host_agent/src/agent_cli.rs
@@ -211,7 +211,7 @@ pub enum RemoteCommands {
     },
 
     /// Remotely trigger a NixOS update on a specified host.
-    HostNixosUpdate {
+    HposUpdate {
         #[arg(short, long)]
         device_id: String,
         #[arg(short, long, default_value = "towards-allograph")]

--- a/rust/clients/host_agent/src/agent_cli.rs
+++ b/rust/clients/host_agent/src/agent_cli.rs
@@ -209,4 +209,12 @@ pub enum RemoteCommands {
         #[clap(flatten)]
         request: HcHttpGwRequest,
     },
+
+    /// Remotely trigger a NixOS update on a specified host.
+    HostNixosUpdate {
+        #[arg(short, long)]
+        device_id: String,
+        #[arg(short, long, default_value = "towards-allograph")]
+        channel: String,
+    },
 }

--- a/rust/clients/host_agent/src/hostd/hpos_updates.rs
+++ b/rust/clients/host_agent/src/hostd/hpos_updates.rs
@@ -1,0 +1,75 @@
+use super::utils::create_callback_subject;
+use anyhow::{Context, Result};
+use async_nats::jetstream::kv::Store;
+use db_utils::schemas::workload::WorkloadStateDiscriminants;
+use futures::{StreamExt, TryStreamExt};
+use hpos_hal::inventory::MACHINE_ID_PATH;
+use nats_utils::macros::ApiOptions;
+use nats_utils::{
+    generate_service_call,
+    jetstream_client::JsClient,
+    jetstream_service::JsStreamService,
+    types::{
+        sanitization::sanitize_nats_name,
+        JsServiceBuilder, ServiceConsumerBuilder, ServiceError,
+    },
+};
+use reqwest::Method;
+use std::{collections::HashMap, sync::Arc};
+use tokio::sync::RwLock;
+use url::Url;
+use hpos_updates::{
+    types::HostUpdateServiceSubjects, host_api::HostUpdatesApi,
+    HOST_UPDATES_SRV_DESC, HOST_UPDATES_SRV_NAME, HOST_UPDATES_SRV_SUBJ, HOST_UPDATES_SRV_VERSION,
+    ORCHESTRATOR_SUBJECT_PREFIX, TAG_MAP_PREFIX_DESIGNATED_HOST,
+};
+
+// TODO: Use _host_creds_path for auth once we add in the more resilient auth pattern.
+pub async fn run(
+    host_client: Arc<RwLock<JsClient>>,
+    host_id: &str,
+    jetstream_domain: &str,
+) -> Result<(), async_nats::Error> {
+    log::info!("Host Agent Client: starting workload service...");
+    log::info!("host_id : {}", host_id);
+
+    // Register Workload Streams for Host Agent to consume
+    // NB: Subjects are published by orchestrator or nats-db-connector
+    let host_updates_stream_service = JsServiceBuilder {
+        name: HOST_UPDATES_SRV_NAME.to_string(),
+        description: HOST_UPDATES_SRV_DESC.to_string(),
+        version: HOST_UPDATES_SRV_VERSION.to_string(),
+        service_subject: HOST_UPDATES_SRV_SUBJ.to_string(),
+        maybe_source_js_domain: None,
+    };
+
+    let host_updates_client = host_client
+        .write()
+        .await
+        .add_js_service(host_updates_stream_service)
+        .await?;
+    
+    let host_updates_api = HostUpdatesApi { };
+
+    // Created/ensured by the host agent inventory service (which is started prior to this service)
+    let device_id =
+        std::fs::read_to_string(MACHINE_ID_PATH).context("reading device id from path")?;
+
+    // Request nixos update on host agent
+    host_updates_client
+        .add_consumer(
+            ServiceConsumerBuilder::new(
+                HostUpdateServiceSubjects::Update.as_ref().to_string(), // this sets the subject that will invoke the `handle_host_update` fn
+                HOST_UPDATES_SRV_SUBJ,
+                generate_service_call!(host_updates_api, handle_host_update_command),
+            )
+            .with_subject_prefix(device_id)
+            .with_response_subject_fn(create_callback_subject(
+                HostUpdateServiceSubjects::Status.as_ref().to_string()
+            ))
+            .into(),
+        )
+        .await?;
+
+    Ok(())
+}

--- a/rust/clients/host_agent/src/hostd/hpos_updates.rs
+++ b/rust/clients/host_agent/src/hostd/hpos_updates.rs
@@ -1,45 +1,34 @@
 use super::utils::create_callback_subject;
 use anyhow::{Context, Result};
-use async_nats::jetstream::kv::Store;
-use db_utils::schemas::workload::WorkloadStateDiscriminants;
-use futures::{StreamExt, TryStreamExt};
 use hpos_hal::inventory::MACHINE_ID_PATH;
-use nats_utils::macros::ApiOptions;
+use hpos_updates::{
+    host_api::HostUpdatesApi, types::HostUpdateServiceSubjects, HPOS_UPDATES_SVC_DESC,
+    HPOS_UPDATES_SVC_NAME, HPOS_UPDATES_SVC_SUBJ, HPOS_UPDATES_SVC_VERSION,
+};
 use nats_utils::{
     generate_service_call,
     jetstream_client::JsClient,
-    jetstream_service::JsStreamService,
-    types::{
-        sanitization::sanitize_nats_name,
-        JsServiceBuilder, ServiceConsumerBuilder, ServiceError,
-    },
+    types::{JsServiceBuilder, ServiceConsumerBuilder},
 };
-use reqwest::Method;
-use std::{collections::HashMap, sync::Arc};
+use std::sync::Arc;
 use tokio::sync::RwLock;
-use url::Url;
-use hpos_updates::{
-    types::HostUpdateServiceSubjects, host_api::HostUpdatesApi,
-    HOST_UPDATES_SRV_DESC, HOST_UPDATES_SRV_NAME, HOST_UPDATES_SRV_SUBJ, HOST_UPDATES_SRV_VERSION,
-    ORCHESTRATOR_SUBJECT_PREFIX, TAG_MAP_PREFIX_DESIGNATED_HOST,
-};
 
-// TODO: Use _host_creds_path for auth once we add in the more resilient auth pattern.
 pub async fn run(
     host_client: Arc<RwLock<JsClient>>,
     host_id: &str,
-    jetstream_domain: &str,
 ) -> Result<(), async_nats::Error> {
     log::info!("Host Agent Client: starting workload service...");
     log::info!("host_id : {}", host_id);
 
-    // Register Workload Streams for Host Agent to consume
-    // NB: Subjects are published by orchestrator or nats-db-connector
+    // Note: `MACHINE_ID_PATH` is created by the host agent inventory service
+    let device_id =
+        std::fs::read_to_string(MACHINE_ID_PATH).context("reading device id from path")?;
+
     let host_updates_stream_service = JsServiceBuilder {
-        name: HOST_UPDATES_SRV_NAME.to_string(),
-        description: HOST_UPDATES_SRV_DESC.to_string(),
-        version: HOST_UPDATES_SRV_VERSION.to_string(),
-        service_subject: HOST_UPDATES_SRV_SUBJ.to_string(),
+        name: HPOS_UPDATES_SVC_NAME.to_string(),
+        description: HPOS_UPDATES_SVC_DESC.to_string(),
+        version: HPOS_UPDATES_SVC_VERSION.to_string(),
+        service_subject: HPOS_UPDATES_SVC_SUBJ.to_string(),
         maybe_source_js_domain: None,
     };
 
@@ -48,24 +37,20 @@ pub async fn run(
         .await
         .add_js_service(host_updates_stream_service)
         .await?;
-    
-    let host_updates_api = HostUpdatesApi { };
 
-    // Created/ensured by the host agent inventory service (which is started prior to this service)
-    let device_id =
-        std::fs::read_to_string(MACHINE_ID_PATH).context("reading device id from path")?;
+    let host_updates_api = HostUpdatesApi {};
 
     // Request nixos update on host agent
     host_updates_client
         .add_consumer(
             ServiceConsumerBuilder::new(
                 HostUpdateServiceSubjects::Update.as_ref().to_string(), // this sets the subject that will invoke the `handle_host_update` fn
-                HOST_UPDATES_SRV_SUBJ,
+                HPOS_UPDATES_SVC_SUBJ,
                 generate_service_call!(host_updates_api, handle_host_update_command),
             )
             .with_subject_prefix(device_id)
             .with_response_subject_fn(create_callback_subject(
-                HostUpdateServiceSubjects::Status.as_ref().to_string()
+                HostUpdateServiceSubjects::Status.as_ref().to_string(),
             ))
             .into(),
         )

--- a/rust/clients/host_agent/src/hostd/mod.rs
+++ b/rust/clients/host_agent/src/hostd/mod.rs
@@ -3,3 +3,4 @@ pub mod host_client;
 pub mod inventory;
 pub mod utils;
 pub mod workload;
+pub mod hpos_updates;

--- a/rust/clients/host_agent/src/hostd/utils.rs
+++ b/rust/clients/host_agent/src/hostd/utils.rs
@@ -1,13 +1,13 @@
 use nats_utils::types::ResponseSubjectsGenerator;
 use std::collections::HashMap;
 use std::sync::Arc;
-use workload::WORKLOAD_ORCHESTRATOR_SUBJECT_PREFIX;
+
+// Tag to identify the orchestrator prefix
+pub const ORCHESTRATOR_SUBJECT_PREFIX: &str = "orchestrator";
 
 pub fn create_callback_subject(sub_subject_name: String) -> ResponseSubjectsGenerator {
     Arc::new(move |_tag_map: HashMap<String, String>| -> Vec<String> {
         // TODO(refactor): into event subject
-        vec![format!(
-            "{WORKLOAD_ORCHESTRATOR_SUBJECT_PREFIX}.{sub_subject_name}",
-        )]
+        vec![format!("{ORCHESTRATOR_SUBJECT_PREFIX}.{sub_subject_name}",)]
     })
 }

--- a/rust/clients/host_agent/src/main.rs
+++ b/rust/clients/host_agent/src/main.rs
@@ -117,19 +117,20 @@ async fn daemonize(args: &DaemonzeArgs) -> anyhow::Result<()> {
     let host_id_workload = host_id.clone();
     let host_client_workload = Arc::new(tokio::sync::RwLock::new(host_client.clone()));
     spawn(async move {
-        if let Err(e) =
-            hostd::workload::run(host_client_workload, &host_id_workload, &hub_jetstream_domain).await
+        if let Err(e) = hostd::workload::run(
+            host_client_workload,
+            &host_id_workload,
+            &hub_jetstream_domain,
+        )
+        .await
         {
             log::error!("Error running host agent workload service. Err={:?}", e)
         };
     });
 
-    let hpos_updates_hub_jetstream_domain = args.hub_jetstream_domain.clone();
     let host_client_hpos_updates = Arc::new(tokio::sync::RwLock::new(host_client.clone()));
     spawn(async move {
-        if let Err(e) =
-            hostd::hpos_updates::run(host_client_hpos_updates, &host_id, &hpos_updates_hub_jetstream_domain).await
-        {
+        if let Err(e) = hostd::hpos_updates::run(host_client_hpos_updates, &host_id).await {
             log::error!("Error running hpos updates service. Err={:?}", e)
         };
     });

--- a/rust/clients/host_agent/src/main.rs
+++ b/rust/clients/host_agent/src/main.rs
@@ -114,12 +114,23 @@ async fn daemonize(args: &DaemonzeArgs) -> anyhow::Result<()> {
     }
 
     let hub_jetstream_domain = args.hub_jetstream_domain.clone();
+    let host_id_workload = host_id.clone();
     let host_client_workload = Arc::new(tokio::sync::RwLock::new(host_client.clone()));
     spawn(async move {
         if let Err(e) =
-            hostd::workload::run(host_client_workload, &host_id, &hub_jetstream_domain).await
+            hostd::workload::run(host_client_workload, &host_id_workload, &hub_jetstream_domain).await
         {
             log::error!("Error running host agent workload service. Err={:?}", e)
+        };
+    });
+
+    let hpos_updates_hub_jetstream_domain = args.hub_jetstream_domain.clone();
+    let host_client_hpos_updates = Arc::new(tokio::sync::RwLock::new(host_client.clone()));
+    spawn(async move {
+        if let Err(e) =
+            hostd::hpos_updates::run(host_client_hpos_updates, &host_id, &hpos_updates_hub_jetstream_domain).await
+        {
+            log::error!("Error running hpos updates service. Err={:?}", e)
         };
     });
 

--- a/rust/clients/host_agent/src/remote_cmds/mod.rs
+++ b/rust/clients/host_agent/src/remote_cmds/mod.rs
@@ -8,6 +8,10 @@ use nats_utils::{jetstream_client::JsClient, types::JsClientBuilder};
 use std::str::FromStr;
 use std::sync::Arc;
 use workload::types::{WorkloadResult, WorkloadServiceSubjects};
+use workload::WORKLOAD_ORCHESTRATOR_SUBJECT_PREFIX;
+use hpos_updates::types::{HostUpdateResponseInfo,HostUpdateRequest, HostUpdateServiceSubjects, HostUpdateApiResult};
+use hpos_updates::HOST_UPDATES_SRV_SUBJ;
+use chrono::Utc;
 
 use crate::agent_cli::{self, RemoteArgs, RemoteCommands};
 
@@ -144,40 +148,46 @@ pub(crate) async fn run(args: RemoteArgs, command: RemoteCommands) -> anyhow::Re
             println!("{response:?}");
         }
 
-        agent_cli::RemoteCommands::HostNixosUpdate { device_id, channel } => {
-            let subject = format!(
-                "{}.{}.{}",
-                HOST_UPDATES_SRV_SUBJ,
-                ORCHESTRATOR_SUBJECT_PREFIX,
-                HostUpdateServiceSubjects::Update.as_ref().to_string()
-            );
+        // agent_cli::RemoteCommands::HostNixosUpdate { device_id, channel } => {
+        //     let subject = format!(
+        //         "{}.{}.{}",
+        //         HOST_UPDATES_SRV_SUBJ,
+        //         WORKLOAD_ORCHESTRATOR_SUBJECT_PREFIX,
+        //         HostUpdateServiceSubjects::Update.as_ref().to_string()
+        //     );
 
-            let update_request = HostUpdateRequest {
-                info: "Host NixOS update requested from Remote CLI".to_string(),
-                device_id,
-                channel,
-            };
+        //     let update_request = HostUpdateResponseInfo {
+        //         info: "Host NixOS update requested from Remote CLI".to_string(),
+        //         request_info: HostUpdateRequest {
+        //             device_id,
+        //             channel,
+        //         }
+        //     };
 
-            log::debug!("publishing to {subject}: {payload}");
-            let timestamp = Utc::now().to_rfc3339();
+        //     let payload = HostUpdateApiResult {
+        //         HostUpdateApiResult::Success(update_request)
+        //     };
 
-            if let Ok(response) = nats_client
-                .publish(PublishInfo {
-                    subject,
-                    msg_id: timestamp,
-                    data: update_request.into(),
-                    headers: None,
-                })
-                .await
-            {
-                log::info!(
-                    "Completed request to update the nixos channel on Host.
-                host={device_id},
-                channel={channel},
-                response={response:#?}"
-                );
-            };
-        }
+        //     log::debug!("publishing to {subject}: payload={:?}", payload);
+        //     let timestamp = Utc::now().to_rfc3339();
+
+        //     if let Ok(response) = nats_client
+        //         .publish(PublishInfo {
+        //             subject,
+        //             msg_id: timestamp,
+        //             data: payload.into(),
+        //             headers: None,
+        //         })
+        //         .await
+        //     {
+        //         log::info!(
+        //             "Completed request to update the nixos channel on Host.
+        //         host={device_id},
+        //         channel={channel},
+        //         response={response:#?}"
+        //         );
+        //     };
+        // }
     }
 
     Ok(())

--- a/rust/clients/host_agent/src/remote_cmds/mod.rs
+++ b/rust/clients/host_agent/src/remote_cmds/mod.rs
@@ -149,7 +149,7 @@ pub(crate) async fn run(args: RemoteArgs, command: RemoteCommands) -> anyhow::Re
         }
 
         // Manaul remote way to request a given host to update its nixos channel
-        agent_cli::RemoteCommands::HostNixosUpdate { device_id, channel } => {
+        agent_cli::RemoteCommands::HposUpdate { device_id, channel } => {
             let subject = format!(
                 "{}.{}.{}",
                 HPOS_UPDATES_SVC_SUBJ,

--- a/rust/clients/host_agent/src/remote_cmds/mod.rs
+++ b/rust/clients/host_agent/src/remote_cmds/mod.rs
@@ -1,17 +1,17 @@
+use crate::hostd::utils::ORCHESTRATOR_SUBJECT_PREFIX;
 use anyhow::Context;
+use chrono::Utc;
 use db_utils::schemas::workload::{
     Workload, WorkloadManifest, WorkloadState, WorkloadStateDiscriminants, WorkloadStatus,
 };
 use futures::StreamExt;
+use hpos_updates::types::{HostUpdateRequest, HostUpdateServiceSubjects};
+use hpos_updates::HPOS_UPDATES_SVC_SUBJ;
 use nats_utils::types::PublishInfo;
 use nats_utils::{jetstream_client::JsClient, types::JsClientBuilder};
 use std::str::FromStr;
 use std::sync::Arc;
 use workload::types::{WorkloadResult, WorkloadServiceSubjects};
-use workload::WORKLOAD_ORCHESTRATOR_SUBJECT_PREFIX;
-use hpos_updates::types::{HostUpdateResponseInfo,HostUpdateRequest, HostUpdateServiceSubjects, HostUpdateApiResult};
-use hpos_updates::HOST_UPDATES_SRV_SUBJ;
-use chrono::Utc;
 
 use crate::agent_cli::{self, RemoteArgs, RemoteCommands};
 
@@ -148,46 +148,38 @@ pub(crate) async fn run(args: RemoteArgs, command: RemoteCommands) -> anyhow::Re
             println!("{response:?}");
         }
 
-        // agent_cli::RemoteCommands::HostNixosUpdate { device_id, channel } => {
-        //     let subject = format!(
-        //         "{}.{}.{}",
-        //         HOST_UPDATES_SRV_SUBJ,
-        //         WORKLOAD_ORCHESTRATOR_SUBJECT_PREFIX,
-        //         HostUpdateServiceSubjects::Update.as_ref().to_string()
-        //     );
+        // Manaul remote way to request a given host to update its nixos channel
+        agent_cli::RemoteCommands::HostNixosUpdate { device_id, channel } => {
+            let subject = format!(
+                "{}.{}.{}",
+                HPOS_UPDATES_SVC_SUBJ,
+                ORCHESTRATOR_SUBJECT_PREFIX,
+                HostUpdateServiceSubjects::Update.as_ref().to_string()
+            );
 
-        //     let update_request = HostUpdateResponseInfo {
-        //         info: "Host NixOS update requested from Remote CLI".to_string(),
-        //         request_info: HostUpdateRequest {
-        //             device_id,
-        //             channel,
-        //         }
-        //     };
+            let request_log_msg = format!(
+                "Completed request to update the nixos channel on Host. host={device_id}, channel={channel}"
+            );
 
-        //     let payload = HostUpdateApiResult {
-        //         HostUpdateApiResult::Success(update_request)
-        //     };
+            let request_info = HostUpdateRequest { device_id, channel };
+            let payload = serde_json::to_string_pretty(&request_info)
+                .context("Error serializing request_info")?;
 
-        //     log::debug!("publishing to {subject}: payload={:?}", payload);
-        //     let timestamp = Utc::now().to_rfc3339();
+            log::debug!("publishing to {subject}: payload={:?}", payload);
+            let timestamp = Utc::now().to_rfc3339();
 
-        //     if let Ok(response) = nats_client
-        //         .publish(PublishInfo {
-        //             subject,
-        //             msg_id: timestamp,
-        //             data: payload.into(),
-        //             headers: None,
-        //         })
-        //         .await
-        //     {
-        //         log::info!(
-        //             "Completed request to update the nixos channel on Host.
-        //         host={device_id},
-        //         channel={channel},
-        //         response={response:#?}"
-        //         );
-        //     };
-        // }
+            if let Ok(response) = nats_client
+                .publish(PublishInfo {
+                    subject,
+                    msg_id: timestamp,
+                    data: payload.into(),
+                    headers: None,
+                })
+                .await
+            {
+                log::info!("{request_log_msg}, response={response:#?}");
+            };
+        }
     }
 
     Ok(())

--- a/rust/clients/orchestrator/Cargo.toml
+++ b/rust/clients/orchestrator/Cargo.toml
@@ -21,6 +21,7 @@ nats_utils = { workspace = true }
 db_utils = { workspace = true }
 workload = { workspace = true }
 inventory = { workspace = true }
+hpos_updates = { workspace = true }
 url = { version = "2", features = ["serde"] }
 bson = { version = "2.6.1", features = ["chrono-0_4"] }
 serde_with = { version = "3.1", features = ["macros"] }

--- a/rust/clients/orchestrator/src/hpos_updates.rs
+++ b/rust/clients/orchestrator/src/hpos_updates.rs
@@ -1,0 +1,73 @@
+use std::sync::Arc;
+
+use anyhow::Result;
+use hpos_updates::{
+    HostUpdatesServiceApi, OrchestratorHostUpdatesApi, HOST_UPDATES_SRV_DESC,
+    HOST_UPDATES_SRV_NAME, HOST_UPDATES_SRV_SUBJ, HOST_UPDATES_SRV_VERSION, HOST_UPDATES_SUBJECT,
+    TAG_MAP_PREFIX_ASSIGNED_HOST,
+};
+use mongodb::Client as MongoDBClient;
+use nats_utils::{
+    generate_service_call,
+    jetstream_client::JsClient,
+    types::{JsServiceBuilder, ResponseSubjectsGenerator, ServiceConsumerBuilder},
+};
+use std::collections::HashMap;
+
+pub fn create_callback_subject(sub_subject_name: String) -> ResponseSubjectsGenerator {
+    Arc::new(move |_tag_map: HashMap<String, String>| -> Vec<String> {
+        vec![format!(
+            "{WORKLOAD_ORCHESTRATOR_SUBJECT_PREFIX}.{sub_subject_name}",
+        )]
+    })
+}
+
+pub async fn run(
+    mut nats_client: JsClient,
+    db_client: MongoDBClient,
+) -> Result<(), async_nats::Error> {
+    // Setup JS Stream Service
+    let host_updates_stream_service = JsServiceBuilder {
+        name: HOST_UPDATES_SRV_NAME.to_string(),
+        description: HOST_UPDATES_SRV_DESC.to_string(),
+        version: HOST_UPDATES_SRV_VERSION.to_string(),
+        service_subject: HOST_UPDATES_SRV_SUBJ.to_string(),
+        maybe_source_js_domain: None,
+    };
+    let host_updates_client = nats_client
+        .add_js_service(host_updates_stream_service)
+        .await?;
+
+    // Instantiate the Host Updates API (requires access to db client)
+    let host_updates_api = Arc::new(OrchestratorHostUpdatesApi::new(&db_client).await?);
+
+    host_updates_client
+        .add_consumer(
+            ServiceConsumerBuilder::new(
+                "handle_host_update_response".to_string(),
+                HOST_UPDATES_SUBJECT,
+                generate_service_call!(host_updates_api, handle_host_update_response),
+            )
+            .with_subject_prefix("*".to_string())
+            .into(),
+        )
+        .await?;
+
+    // Subjects published by hosting agent:
+    host_updates_client
+        .add_consumer(
+            ServiceConsumerBuilder::new(
+                "update_host_channel".to_string(),
+                HOST_UPDATES_SUBJECT,
+                generate_service_call!(host_updates_api, handle_host_update),
+            )
+            .with_response_subject_fn(create_callback_subject_to_host(
+                true,
+                TAG_MAP_PREFIX_ASSIGNED_HOST.to_string(),
+                "handle_host_update".to_string(), // this is the subject the host agent will subcribe / listen to
+            )),
+        )
+        .await?;
+
+    Ok(())
+}

--- a/rust/clients/orchestrator/src/hpos_updates.rs
+++ b/rust/clients/orchestrator/src/hpos_updates.rs
@@ -1,26 +1,17 @@
-use std::sync::Arc;
-
+use super::utils::create_callback_subject_to_host;
 use anyhow::Result;
 use hpos_updates::{
-    HostUpdatesServiceApi, OrchestratorHostUpdatesApi, HOST_UPDATES_SRV_DESC,
-    HOST_UPDATES_SRV_NAME, HOST_UPDATES_SRV_SUBJ, HOST_UPDATES_SRV_VERSION, HOST_UPDATES_SUBJECT,
-    TAG_MAP_PREFIX_ASSIGNED_HOST,
+    orchestrator_api::OrchestratorHostUpdatesApi, types::HostUpdateServiceSubjects,
+    HOST_UPDATES_SRV_DESC, HOST_UPDATES_SRV_NAME, HOST_UPDATES_SRV_SUBJ, HOST_UPDATES_SRV_VERSION,
+    HOST_UPDATES_SUBJECT, ORCHESTRATOR_SUBJECT_PREFIX, TAG_MAP_PREFIX_DESIGNATED_HOST,
 };
 use mongodb::Client as MongoDBClient;
 use nats_utils::{
     generate_service_call,
     jetstream_client::JsClient,
-    types::{JsServiceBuilder, ResponseSubjectsGenerator, ServiceConsumerBuilder},
+    types::{JsServiceBuilder, ServiceConsumerBuilder},
 };
-use std::collections::HashMap;
-
-pub fn create_callback_subject(sub_subject_name: String) -> ResponseSubjectsGenerator {
-    Arc::new(move |_tag_map: HashMap<String, String>| -> Vec<String> {
-        vec![format!(
-            "{WORKLOAD_ORCHESTRATOR_SUBJECT_PREFIX}.{sub_subject_name}",
-        )]
-    })
-}
+use std::sync::Arc;
 
 pub async fn run(
     mut nats_client: JsClient,
@@ -41,31 +32,34 @@ pub async fn run(
     // Instantiate the Host Updates API (requires access to db client)
     let host_updates_api = Arc::new(OrchestratorHostUpdatesApi::new(&db_client).await?);
 
+    // Request nixos update on host agent
     host_updates_client
         .add_consumer(
             ServiceConsumerBuilder::new(
-                "handle_host_update_response".to_string(),
+                HostUpdateServiceSubjects::Update.as_ref().to_string(), // this sets the subject that will invoke the `handle_host_update` fn
                 HOST_UPDATES_SUBJECT,
-                generate_service_call!(host_updates_api, handle_host_update_response),
+                generate_service_call!(host_updates_api, handle_host_update),
             )
-            .with_subject_prefix("*".to_string())
+            .with_subject_prefix(ORCHESTRATOR_SUBJECT_PREFIX.to_string())
+            .with_response_subject_fn(create_callback_subject_to_host(
+                true,
+                TAG_MAP_PREFIX_DESIGNATED_HOST.to_string(),
+                HostUpdateServiceSubjects::Update.as_ref().to_string(), // this references the subject to which the host agent has subscribed (note: it will be prefixed by the device_id)
+            ))
             .into(),
         )
         .await?;
 
-    // Subjects published by hosting agent:
+    // Handle nixos update response from host agent
     host_updates_client
         .add_consumer(
             ServiceConsumerBuilder::new(
-                "update_host_channel".to_string(),
+                HostUpdateServiceSubjects::Status.as_ref().to_string(), // this sets the subject that will invoke the `handle_host_update` fn (prefixed by orchestrator)
                 HOST_UPDATES_SUBJECT,
-                generate_service_call!(host_updates_api, handle_host_update),
+                generate_service_call!(host_updates_api, handle_host_update_response),
             )
-            .with_response_subject_fn(create_callback_subject_to_host(
-                true,
-                TAG_MAP_PREFIX_ASSIGNED_HOST.to_string(),
-                "handle_host_update".to_string(), // this is the subject the host agent will subcribe / listen to
-            )),
+            .with_subject_prefix(ORCHESTRATOR_SUBJECT_PREFIX.to_string())
+            .into(),
         )
         .await?;
 

--- a/rust/clients/orchestrator/src/hpos_updates.rs
+++ b/rust/clients/orchestrator/src/hpos_updates.rs
@@ -1,9 +1,9 @@
-use super::utils::create_callback_subject_to_host;
+use super::utils::{create_callback_subject_to_host, ORCHESTRATOR_SUBJECT_PREFIX};
 use anyhow::Result;
 use hpos_updates::{
-    orchestrator_api::OrchestratorHostUpdatesApi, types::HostUpdateServiceSubjects,
-    HOST_UPDATES_SRV_DESC, HOST_UPDATES_SRV_NAME, HOST_UPDATES_SRV_SUBJ, HOST_UPDATES_SRV_VERSION,
-    ORCHESTRATOR_SUBJECT_PREFIX, TAG_MAP_PREFIX_DESIGNATED_HOST,
+    orchestrator_api::OrchestratorHposUpdatesApi, types::HostUpdateServiceSubjects,
+    HPOS_UPDATES_SVC_DESC, HPOS_UPDATES_SVC_NAME, HPOS_UPDATES_SVC_SUBJ, HPOS_UPDATES_SVC_VERSION,
+    TAG_MAP_PREFIX_DESIGNATED_HOST,
 };
 use mongodb::Client as MongoDBClient;
 use nats_utils::{
@@ -19,10 +19,10 @@ pub async fn run(
 ) -> Result<(), async_nats::Error> {
     // Setup JS Stream Service
     let host_updates_stream_service = JsServiceBuilder {
-        name: HOST_UPDATES_SRV_NAME.to_string(),
-        description: HOST_UPDATES_SRV_DESC.to_string(),
-        version: HOST_UPDATES_SRV_VERSION.to_string(),
-        service_subject: HOST_UPDATES_SRV_SUBJ.to_string(),
+        name: HPOS_UPDATES_SVC_NAME.to_string(),
+        description: HPOS_UPDATES_SVC_DESC.to_string(),
+        version: HPOS_UPDATES_SVC_VERSION.to_string(),
+        service_subject: HPOS_UPDATES_SVC_SUBJ.to_string(),
         maybe_source_js_domain: None,
     };
     let host_updates_client = nats_client
@@ -30,14 +30,14 @@ pub async fn run(
         .await?;
 
     // Instantiate the Host Updates API (requires access to db client)
-    let host_updates_api = Arc::new(OrchestratorHostUpdatesApi::new(&db_client).await?);
+    let host_updates_api = Arc::new(OrchestratorHposUpdatesApi::new(&db_client).await?);
 
     // Request nixos update on host agent
     host_updates_client
         .add_consumer(
             ServiceConsumerBuilder::new(
                 HostUpdateServiceSubjects::Update.as_ref().to_string(), // this sets the subject that will invoke the `handle_host_update` fn
-                HOST_UPDATES_SRV_SUBJ,
+                HPOS_UPDATES_SVC_SUBJ,
                 generate_service_call!(host_updates_api, handle_host_update),
             )
             .with_subject_prefix(ORCHESTRATOR_SUBJECT_PREFIX.to_string())
@@ -55,7 +55,7 @@ pub async fn run(
         .add_consumer(
             ServiceConsumerBuilder::new(
                 HostUpdateServiceSubjects::Status.as_ref().to_string(), // this sets the subject that will invoke the `handle_host_update` fn (prefixed by orchestrator)
-                HOST_UPDATES_SRV_SUBJ,
+                HPOS_UPDATES_SVC_SUBJ,
                 generate_service_call!(host_updates_api, handle_host_update_response),
             )
             .with_subject_prefix(ORCHESTRATOR_SUBJECT_PREFIX.to_string())

--- a/rust/clients/orchestrator/src/hpos_updates.rs
+++ b/rust/clients/orchestrator/src/hpos_updates.rs
@@ -3,7 +3,7 @@ use anyhow::Result;
 use hpos_updates::{
     orchestrator_api::OrchestratorHostUpdatesApi, types::HostUpdateServiceSubjects,
     HOST_UPDATES_SRV_DESC, HOST_UPDATES_SRV_NAME, HOST_UPDATES_SRV_SUBJ, HOST_UPDATES_SRV_VERSION,
-    HOST_UPDATES_SUBJECT, ORCHESTRATOR_SUBJECT_PREFIX, TAG_MAP_PREFIX_DESIGNATED_HOST,
+    ORCHESTRATOR_SUBJECT_PREFIX, TAG_MAP_PREFIX_DESIGNATED_HOST,
 };
 use mongodb::Client as MongoDBClient;
 use nats_utils::{
@@ -37,7 +37,7 @@ pub async fn run(
         .add_consumer(
             ServiceConsumerBuilder::new(
                 HostUpdateServiceSubjects::Update.as_ref().to_string(), // this sets the subject that will invoke the `handle_host_update` fn
-                HOST_UPDATES_SUBJECT,
+                HOST_UPDATES_SRV_SUBJ,
                 generate_service_call!(host_updates_api, handle_host_update),
             )
             .with_subject_prefix(ORCHESTRATOR_SUBJECT_PREFIX.to_string())
@@ -55,7 +55,7 @@ pub async fn run(
         .add_consumer(
             ServiceConsumerBuilder::new(
                 HostUpdateServiceSubjects::Status.as_ref().to_string(), // this sets the subject that will invoke the `handle_host_update` fn (prefixed by orchestrator)
-                HOST_UPDATES_SUBJECT,
+                HOST_UPDATES_SRV_SUBJ,
                 generate_service_call!(host_updates_api, handle_host_update_response),
             )
             .with_subject_prefix(ORCHESTRATOR_SUBJECT_PREFIX.to_string())

--- a/rust/clients/orchestrator/src/main.rs
+++ b/rust/clients/orchestrator/src/main.rs
@@ -64,6 +64,15 @@ async fn main() -> Result<(), async_nats::Error> {
         };
     });
 
+    let admin_host_agent_clone = admin_client.clone();
+    let db_host_agent_clone = db_client.clone();
+    spawn(async move {
+        log::info!("Starting host agent service...");
+        if let Err(e) = hpos_updates::run(admin_host_agent_clone, db_host_agent_clone).await {
+            log::error!("Error running host agent service. Err={:?}", e)
+        };
+    });
+
     // Only exit program when explicitly requested
     tokio::signal::ctrl_c().await?;
 

--- a/rust/clients/orchestrator/src/main.rs
+++ b/rust/clients/orchestrator/src/main.rs
@@ -1,5 +1,6 @@
 mod admin_client;
 mod extern_api;
+mod hpos_updates;
 mod inventory;
 mod utils;
 mod workloads;

--- a/rust/clients/orchestrator/src/utils.rs
+++ b/rust/clients/orchestrator/src/utils.rs
@@ -7,6 +7,9 @@ use serde::Serialize;
 use std::collections::HashMap;
 use std::sync::Arc;
 
+// Tag to identify the orchestrator prefix
+pub const ORCHESTRATOR_SUBJECT_PREFIX: &str = "orchestrator";
+
 pub async fn add_workload_consumer<S, R>(
     service_builder: ServiceConsumerBuilder<S, R>,
     workload_service: &JsStreamService,

--- a/rust/clients/orchestrator/src/workloads.rs
+++ b/rust/clients/orchestrator/src/workloads.rs
@@ -16,7 +16,9 @@ This client is responsible for:
 
 use std::sync::Arc;
 
-use super::utils::{add_workload_consumer, create_callback_subject_to_host};
+use super::utils::{
+    add_workload_consumer, create_callback_subject_to_host, ORCHESTRATOR_SUBJECT_PREFIX,
+};
 use anyhow::Result;
 use mongodb::Client as MongoDBClient;
 use nats_utils::{
@@ -27,8 +29,8 @@ use nats_utils::{
 use std::time::Duration;
 use workload::{
     orchestrator_api::OrchestratorWorkloadApi, types::WorkloadServiceSubjects,
-    TAG_MAP_PREFIX_ASSIGNED_HOST, WORKLOAD_ORCHESTRATOR_SUBJECT_PREFIX, WORKLOAD_SRV_DESC,
-    WORKLOAD_SRV_NAME, WORKLOAD_SRV_SUBJ, WORKLOAD_SRV_VERSION,
+    TAG_MAP_PREFIX_ASSIGNED_HOST, WORKLOAD_SRV_DESC, WORKLOAD_SRV_NAME, WORKLOAD_SRV_SUBJ,
+    WORKLOAD_SRV_VERSION,
 };
 
 pub async fn run(
@@ -122,7 +124,7 @@ pub async fn run(
             WorkloadServiceSubjects::HandleStatusUpdate,
             generate_service_call!(workload_api, handle_status_update),
         )
-        .with_subject_prefix(WORKLOAD_ORCHESTRATOR_SUBJECT_PREFIX.to_string()),
+        .with_subject_prefix(ORCHESTRATOR_SUBJECT_PREFIX.to_string()),
         &workload_service,
     )
     .await?;

--- a/rust/services/hpos_updates/Cargo.toml
+++ b/rust/services/hpos_updates/Cargo.toml
@@ -18,11 +18,13 @@ nats_utils = { workspace = true }
 hpos-hal = { workspace = true }
 env_logger = { workspace = true }
 bson = { version = "2.6.1", features = ["chrono-0_4"] }
+async-trait = "0.1.83"
 mongodb = "3.1"
 base32 = "0.5.1"
 nkeys = "=0.4.4"
 sha2 = "=0.10.8"
 nats-jwt = "0.3.0"
+strum_macros = "0.25"
 data-encoding = "2.7.0"
 jsonwebtoken = "9.3.0"
 bytes = "1.8.0"

--- a/rust/services/hpos_updates/Cargo.toml
+++ b/rust/services/hpos_updates/Cargo.toml
@@ -1,0 +1,38 @@
+[package]
+name = "hpos_updates"
+version = "0.0.1"
+edition = "2021"
+
+[lib]
+path = "src/lib.rs"
+
+[dependencies]
+tokio = { workspace = true }
+anyhow = { workspace = true }
+async-nats = { workspace = true }
+log = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+db_utils = { workspace = true }
+nats_utils = { workspace = true }
+hpos-hal = { workspace = true }
+env_logger = { workspace = true }
+bson = { version = "2.6.1", features = ["chrono-0_4"] }
+mongodb = "3.1"
+base32 = "0.5.1"
+nkeys = "=0.4.4"
+sha2 = "=0.10.8"
+nats-jwt = "0.3.0"
+data-encoding = "2.7.0"
+jsonwebtoken = "9.3.0"
+bytes = "1.8.0"
+
+[dev-dependencies]
+tempfile = "3.8"
+ctor = "0.2"
+serial_test = "2.0"
+dotenv = { workspace = true }
+mock_utils = { workspace = true }
+
+[features]
+tests_integration_inventory_service = []

--- a/rust/services/hpos_updates/src/host_api.rs
+++ b/rust/services/hpos_updates/src/host_api.rs
@@ -1,45 +1,107 @@
 use super::{
-    types::{HostUpdateApiResult, HostUpdateRequest, HostUpdateResponseInfo, HostUpdateResult},
-    HostUpdatesServiceApi, TAG_MAP_PREFIX_DESIGNATED_HOST,
+    types::{HostUpdateApiRequest, HostUpdateInfo, HostUpdateState},
+    utils, HposUpdatesServiceApi,
 };
-use anyhow::Result;
 use async_nats::Message;
-use bson::{self, doc};
 use nats_utils::types::ServiceError;
-use std::{collections::HashMap, fmt::Debug, sync::Arc};
+use std::{fmt::Debug, sync::Arc};
 
 #[derive(Clone, Debug)]
 pub struct HostUpdatesApi {}
 
-impl HostUpdatesServiceApi for HostUpdatesApi {}
+impl HposUpdatesServiceApi for HostUpdatesApi {}
 
 impl HostUpdatesApi {
-    pub async fn handle_host_update_command(&self, msg: Arc<Message>) -> Result<HostUpdateApiResult, ServiceError>  {
-    let host_command = Self::convert_msg_to_type::<HostUpdateResult>(msg)?;
+    pub async fn handle_host_update_command(
+        &self,
+        msg: Arc<Message>,
+    ) -> Result<HostUpdateApiRequest, ServiceError> {
+        let host_update_info = Self::convert_msg_to_type::<HostUpdateInfo>(msg)?;
 
-        let r = match host_command {
-            HostUpdateResult::Success(info) => {
-                let channel = info.request_info.channel.clone();
-                let device_id = info.request_info.device_id.clone();
+        let info: HostUpdateInfo = match host_update_info.state {
+            HostUpdateState::Pending => {
+                let channel = host_update_info.request_info.channel.clone();
+                let device_id = host_update_info.request_info.device_id.clone();
 
-                // handle update here
-                self.nixos_channel_update(channel.clone(), device_id.clone());
+                log::info!("Processing NixOS channel update request: channel={channel}, device_id={device_id}");
 
-                HostUpdateResult::Success(HostUpdateResponseInfo {
-                    info: format!("Successfully added the Nixos channel to {} on device {}", channel, device_id),
-                    request_info: info.request_info
-                })
+                // Perform NixOS channel switch and rebuild
+                match self.update_nixos_channel(&channel, &device_id).await {
+                    Ok(_) => HostUpdateInfo {
+                        request_info: host_update_info.request_info,
+                        state: HostUpdateState::Completed,
+                        context: Some(format!(
+                            "Successfully updated NixOS channel to {} on device {}",
+                            channel, device_id
+                        )),
+                    },
+                    Err(e) => HostUpdateInfo {
+                        request_info: host_update_info.request_info,
+                        state: HostUpdateState::Failed,
+                        context: Some(format!("Failed to update NixOS channel: {}", e)),
+                    },
+                }
             }
-            HostUpdateResult::Error(e)  => HostUpdateResult::Error(e)
+            HostUpdateState::Completed | HostUpdateState::Failed => {
+                log::warn!(
+                    "Host Agent received unexpected state in hpos update request. Ignoring hpos update request. host_update_info={host_update_info:?}"
+                );
+                host_update_info
+            }
         };
 
-        Ok(HostUpdateApiResult {
-            result: r, 
+        Ok(HostUpdateApiRequest {
+            info,
             maybe_response_tags: None,
-            maybe_headers: None
+            maybe_headers: None,
         })
-
     }
 
-    async fn nixos_channel_update(&self, channel: String, device_id: String) {}
+    // Draft for update (using bash :|)
+    async fn update_nixos_channel(
+        &self,
+        channel: &str,
+        device_id: &str,
+    ) -> Result<(), ServiceError> {
+        log::info!(
+            "Starting NixOS channel update for device {} to channel {}",
+            device_id,
+            channel
+        );
+
+        // TODO: Add a check to see if the channel is already the current channel before attempting to switch/rebuild
+        // TODO: Add a check to see if the channel is a valid channel
+
+        // Step 1: Switch to the new channel
+        let switch_cmd = format!(
+            "nix-channel --add https://nixos.org/channels/nixos-{} nixos",
+            channel
+        );
+
+        log::debug!("Executing channel switch command: {}", switch_cmd);
+        utils::bash(&switch_cmd).await.map_err(|e| {
+            ServiceError::internal(format!("Failed to switch NixOS channel: {}", e), None)
+        })?;
+
+        // Step 2: Update the channel
+        let update_cmd = "nix-channel --update";
+        log::debug!("Executing channel update command: {}", update_cmd);
+        utils::bash(update_cmd).await.map_err(|e| {
+            ServiceError::internal(format!("Failed to update NixOS channel: {}", e), None)
+        })?;
+
+        // Step 3: Rebuild the system
+        let rebuild_cmd = "nixos-rebuild switch";
+        log::debug!("Executing system rebuild command: {}", rebuild_cmd);
+        utils::bash(rebuild_cmd).await.map_err(|e| {
+            ServiceError::internal(format!("Failed to rebuild NixOS system: {}", e), None)
+        })?;
+
+        log::info!(
+            "Successfully completed NixOS channel update for device {} to channel {}",
+            device_id,
+            channel
+        );
+        Ok(())
+    }
 }

--- a/rust/services/hpos_updates/src/host_api.rs
+++ b/rust/services/hpos_updates/src/host_api.rs
@@ -1,0 +1,45 @@
+use super::{
+    types::{HostUpdateApiResult, HostUpdateRequest, HostUpdateResponseInfo, HostUpdateResult},
+    HostUpdatesServiceApi, TAG_MAP_PREFIX_DESIGNATED_HOST,
+};
+use anyhow::Result;
+use async_nats::Message;
+use bson::{self, doc};
+use nats_utils::types::ServiceError;
+use std::{collections::HashMap, fmt::Debug, sync::Arc};
+
+#[derive(Clone, Debug)]
+pub struct HostUpdatesApi {}
+
+impl HostUpdatesServiceApi for HostUpdatesApi {}
+
+impl HostUpdatesApi {
+    pub async fn handle_host_update_command(&self, msg: Arc<Message>) -> Result<HostUpdateApiResult, ServiceError>  {
+    let host_command = Self::convert_msg_to_type::<HostUpdateResult>(msg)?;
+
+        let r = match host_command {
+            HostUpdateResult::Success(info) => {
+                let channel = info.request_info.channel.clone();
+                let device_id = info.request_info.device_id.clone();
+
+                // handle update here
+                self.nixos_channel_update(channel.clone(), device_id.clone());
+
+                HostUpdateResult::Success(HostUpdateResponseInfo {
+                    info: format!("Successfully added the Nixos channel to {} on device {}", channel, device_id),
+                    request_info: info.request_info
+                })
+            }
+            HostUpdateResult::Error(e)  => HostUpdateResult::Error(e)
+        };
+
+        Ok(HostUpdateApiResult {
+            result: r, 
+            maybe_response_tags: None,
+            maybe_headers: None
+        })
+
+    }
+
+    async fn nixos_channel_update(&self, channel: String, device_id: String) {}
+}

--- a/rust/services/hpos_updates/src/lib.rs
+++ b/rust/services/hpos_updates/src/lib.rs
@@ -1,41 +1,30 @@
-mod orchestrator_api;
-mod types;
+pub mod orchestrator_api;
+pub mod types;
 
 use anyhow::Result;
 use async_nats::jetstream::ErrorCode;
 use async_nats::Message;
 use async_trait::async_trait;
-use bson::{self, doc, oid::ObjectId, DateTime};
-use db_utils::{
-    mongodb::{
-        api::MongoDbAPI,
-        collection::MongoCollection,
-        traits::{IntoIndexes, MutMetadata},
-    },
-    schemas::{
-        self,
-        host::{Host, HOST_COLLECTION_NAME},
-        workload::{Workload, WORKLOAD_COLLECTION_NAME},
-    },
+use db_utils::mongodb::{
+    collection::MongoCollection,
+    traits::{IntoIndexes, MutMetadata},
 };
-use mongodb::{options::UpdateModifications, Client as MongoDBClient};
+use db_utils::schemas;
+use mongodb::Client as MongoDBClient;
 use nats_utils::types::ServiceError;
 use serde::{Deserialize, Serialize};
 use std::{fmt::Debug, sync::Arc};
-use types::HostUpdateResult;
-
-// HOST.<machine_id>.update
 
 // api_subject.recipient.action
-/// WORKLOAD.orchestrator.status
-/// WORKLOAD.<device_id>.update
-/// 
-/// NB: Blob store subject:
-/// BLOB_STORE.<object_id>.fetch
-/// 
-/// HOST.orchestrator.update
-/// HOST.orchestrator.status
-/// HOST.<device_id>.update
+// WORKLOAD.orchestrator.status
+// WORKLOAD.<device_id>.update
+//
+// NB: Blob store subject:
+// BLOB_STORE.<object_id>.fetch
+//
+// HOST.orchestrator.update
+// HOST.orchestrator.status
+// HOST.<device_id>.update
 
 pub const HOST_UPDATES_SRV_NAME: &str = "HOST";
 pub const HOST_UPDATES_SRV_SUBJ: &str = "HOST";
@@ -47,25 +36,25 @@ pub const HOST_UPDATES_SRV_DESC: &str =
 pub const HOST_UPDATES_SUBJECT: &str = "update";
 
 // Tag to identify host id
-pub const TAG_MAP_PREFIX_ASSIGNED_HOST: &str = "assigned_host";
+pub const TAG_MAP_PREFIX_DESIGNATED_HOST: &str = "designated_host";
+
 // Tag to identify the orchestrator prefix
 pub const ORCHESTRATOR_SUBJECT_PREFIX: &str = "orchestrator";
 
-#[derive(Clone, Debug)]
-pub struct HostUpdatesServiceApi {
-    pub workload_collection: MongoCollection<Workload>,
-    pub host_collection: MongoCollection<Host>,
-}
-
 #[async_trait]
-pub trait WorkloadServiceApi
+pub trait HostUpdatesServiceApi
 where
     Self: std::fmt::Debug + 'static,
 {
-    async fn new(client: &MongoDBClient) -> Result<Self> {
-        Ok(Self {
-            workload_collection: Self::init_collection(client, WORKLOAD_COLLECTION_NAME).await?,
-            host_collection: Self::init_collection(client, HOST_COLLECTION_NAME).await?,
+    fn convert_msg_to_type<T>(msg: Arc<Message>) -> Result<T, ServiceError>
+    where
+        T: for<'de> Deserialize<'de> + Send + Sync,
+    {
+        serde_json::from_slice::<T>(&msg.payload).map_err(|e| {
+            ServiceError::request(
+                format!("Failed to deserialize payload: {}", e),
+                Some(ErrorCode::BAD_REQUEST),
+            )
         })
     }
 
@@ -87,17 +76,5 @@ where
         let db_name =
             std::env::var("HOLO_DATABASE_NAME").unwrap_or(schemas::DATABASE_NAME.to_string());
         Ok(MongoCollection::<T>::new(client, &db_name, collection_name).await?)
-    }
-
-    fn convert_msg_to_type<T>(msg: Arc<Message>) -> Result<T, ServiceError>
-    where
-        T: for<'de> Deserialize<'de> + Send + Sync,
-    {
-        serde_json::from_slice::<T>(&msg.payload).map_err(|e| {
-            ServiceError::request(
-                format!("Failed to deserialize payload: {}", e),
-                Some(ErrorCode::BAD_REQUEST),
-            )
-        })
     }
 }

--- a/rust/services/hpos_updates/src/lib.rs
+++ b/rust/services/hpos_updates/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod host_api;
 pub mod orchestrator_api;
 pub mod types;
 
@@ -31,9 +32,6 @@ pub const HOST_UPDATES_SRV_SUBJ: &str = "HOST";
 pub const HOST_UPDATES_SRV_VERSION: &str = "0.0.1";
 pub const HOST_UPDATES_SRV_DESC: &str =
     "This service handles the on-command holo-host-agent updates.";
-
-// Service Endpoint Names:
-pub const HOST_UPDATES_SUBJECT: &str = "update";
 
 // Tag to identify host id
 pub const TAG_MAP_PREFIX_DESIGNATED_HOST: &str = "designated_host";

--- a/rust/services/hpos_updates/src/lib.rs
+++ b/rust/services/hpos_updates/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod host_api;
 pub mod orchestrator_api;
 pub mod types;
+mod utils;
 
 use anyhow::Result;
 use async_nats::jetstream::ErrorCode;
@@ -16,31 +17,32 @@ use nats_utils::types::ServiceError;
 use serde::{Deserialize, Serialize};
 use std::{fmt::Debug, sync::Arc};
 
-// api_subject.recipient.action
+// Pattern:
+// API_SUBJECT.recipient.action
+//
+// Examples:
 // WORKLOAD.orchestrator.status
 // WORKLOAD.<device_id>.update
 //
-// NB: Blob store subject:
+// RE: Blob store subject:
 // BLOB_STORE.<object_id>.fetch
 //
-// HOST.orchestrator.update
-// HOST.orchestrator.status
-// HOST.<device_id>.update
+// Subjects for HPOS Updates Service:
+// HPOS.orchestrator.update
+// HPOS.orchestrator.status
+// HPOS.<device_id>.update
 
-pub const HOST_UPDATES_SRV_NAME: &str = "HOST";
-pub const HOST_UPDATES_SRV_SUBJ: &str = "HOST";
-pub const HOST_UPDATES_SRV_VERSION: &str = "0.0.1";
-pub const HOST_UPDATES_SRV_DESC: &str =
+pub const HPOS_UPDATES_SVC_NAME: &str = "HPOS_UPDATES_SERVICE";
+pub const HPOS_UPDATES_SVC_SUBJ: &str = "HPOS";
+pub const HPOS_UPDATES_SVC_VERSION: &str = "0.0.1";
+pub const HPOS_UPDATES_SVC_DESC: &str =
     "This service handles the on-command holo-host-agent updates.";
 
 // Tag to identify host id
 pub const TAG_MAP_PREFIX_DESIGNATED_HOST: &str = "designated_host";
 
-// Tag to identify the orchestrator prefix
-pub const ORCHESTRATOR_SUBJECT_PREFIX: &str = "orchestrator";
-
 #[async_trait]
-pub trait HostUpdatesServiceApi
+pub trait HposUpdatesServiceApi
 where
     Self: std::fmt::Debug + 'static,
 {

--- a/rust/services/hpos_updates/src/lib.rs
+++ b/rust/services/hpos_updates/src/lib.rs
@@ -1,0 +1,103 @@
+mod orchestrator_api;
+mod types;
+
+use anyhow::Result;
+use async_nats::jetstream::ErrorCode;
+use async_nats::Message;
+use async_trait::async_trait;
+use bson::{self, doc, oid::ObjectId, DateTime};
+use db_utils::{
+    mongodb::{
+        api::MongoDbAPI,
+        collection::MongoCollection,
+        traits::{IntoIndexes, MutMetadata},
+    },
+    schemas::{
+        self,
+        host::{Host, HOST_COLLECTION_NAME},
+        workload::{Workload, WORKLOAD_COLLECTION_NAME},
+    },
+};
+use mongodb::{options::UpdateModifications, Client as MongoDBClient};
+use nats_utils::types::ServiceError;
+use serde::{Deserialize, Serialize};
+use std::{fmt::Debug, sync::Arc};
+use types::HostUpdateResult;
+
+// HOST.<machine_id>.update
+
+// api_subject.recipient.action
+/// WORKLOAD.orchestrator.status
+/// WORKLOAD.<device_id>.update
+/// 
+/// NB: Blob store subject:
+/// BLOB_STORE.<object_id>.fetch
+/// 
+/// HOST.orchestrator.update
+/// HOST.orchestrator.status
+/// HOST.<device_id>.update
+
+pub const HOST_UPDATES_SRV_NAME: &str = "HOST";
+pub const HOST_UPDATES_SRV_SUBJ: &str = "HOST";
+pub const HOST_UPDATES_SRV_VERSION: &str = "0.0.1";
+pub const HOST_UPDATES_SRV_DESC: &str =
+    "This service handles the on-command holo-host-agent updates.";
+
+// Service Endpoint Names:
+pub const HOST_UPDATES_SUBJECT: &str = "update";
+
+// Tag to identify host id
+pub const TAG_MAP_PREFIX_ASSIGNED_HOST: &str = "assigned_host";
+// Tag to identify the orchestrator prefix
+pub const ORCHESTRATOR_SUBJECT_PREFIX: &str = "orchestrator";
+
+#[derive(Clone, Debug)]
+pub struct HostUpdatesServiceApi {
+    pub workload_collection: MongoCollection<Workload>,
+    pub host_collection: MongoCollection<Host>,
+}
+
+#[async_trait]
+pub trait WorkloadServiceApi
+where
+    Self: std::fmt::Debug + 'static,
+{
+    async fn new(client: &MongoDBClient) -> Result<Self> {
+        Ok(Self {
+            workload_collection: Self::init_collection(client, WORKLOAD_COLLECTION_NAME).await?,
+            host_collection: Self::init_collection(client, HOST_COLLECTION_NAME).await?,
+        })
+    }
+
+    async fn init_collection<T>(
+        client: &MongoDBClient,
+        collection_name: &str,
+    ) -> Result<MongoCollection<T>>
+    where
+        T: Serialize
+            + for<'de> Deserialize<'de>
+            + Unpin
+            + Send
+            + Sync
+            + Default
+            + Debug
+            + IntoIndexes
+            + MutMetadata,
+    {
+        let db_name =
+            std::env::var("HOLO_DATABASE_NAME").unwrap_or(schemas::DATABASE_NAME.to_string());
+        Ok(MongoCollection::<T>::new(client, &db_name, collection_name).await?)
+    }
+
+    fn convert_msg_to_type<T>(msg: Arc<Message>) -> Result<T, ServiceError>
+    where
+        T: for<'de> Deserialize<'de> + Send + Sync,
+    {
+        serde_json::from_slice::<T>(&msg.payload).map_err(|e| {
+            ServiceError::request(
+                format!("Failed to deserialize payload: {}", e),
+                Some(ErrorCode::BAD_REQUEST),
+            )
+        })
+    }
+}

--- a/rust/services/hpos_updates/src/orchestrator_api.rs
+++ b/rust/services/hpos_updates/src/orchestrator_api.rs
@@ -25,7 +25,7 @@ pub struct OrchestratorHostUpdatesApi {
 impl HostUpdatesServiceApi for OrchestratorHostUpdatesApi {}
 
 impl OrchestratorHostUpdatesApi {
-    pub async fn new(client: &MongoDBClient) -> HostUpdateApiResult<Self> {
+    pub async fn new(client: &MongoDBClient) -> Result<Self> {
         Ok(Self {
             host_collection: Self::init_collection(client, HOST_COLLECTION_NAME).await?,
             _hoster_collection: Self::init_collection(client, HOSTER_COLLECTION_NAME).await?,

--- a/rust/services/hpos_updates/src/orchestrator_api.rs
+++ b/rust/services/hpos_updates/src/orchestrator_api.rs
@@ -8,7 +8,7 @@ use bson::{self, doc};
 use db_utils::{
     mongodb::{api::MongoDbAPI, collection::MongoCollection},
     schemas::{
-        host::{Host, HOST_COLLECTION_NAME},
+        host::{Host, HostStatus, HOST_COLLECTION_NAME},
         hoster::{Hoster, HOSTER_COLLECTION_NAME},
     },
 };
@@ -82,14 +82,22 @@ impl OrchestratorHostUpdatesApi {
 
         log::info!("Orchestrator::handle_host_update_response received: msg={update_result:?}");
 
-        let host_update_status = match update_result.clone() {
-            HostUpdateResult::Success(response_info) => {
-                // manage any special logic for success case
-                response_info
+        let (host_update_status, channel, device_id) = match update_result.clone() {
+            HostUpdateResult::Success(response) => {
+                // TODO: manage any special logic for success case
+                (
+                    HostStatus::Active(response.info),
+                    response.request_info.channel,
+                    response.request_info.device_id,
+                )
             }
-            HostUpdateResult::Error(response_info) => {
-                log::error!("Failed to update host: response_info={response_info:?}");
-                response_info
+            HostUpdateResult::Error(response) => {
+                log::error!("Failed to update host: response_info={:?}", response.info);
+                (
+                    HostStatus::Error(response.info),
+                    response.request_info.channel,
+                    response.request_info.device_id,
+                )
             }
         };
 
@@ -109,8 +117,10 @@ impl OrchestratorHostUpdatesApi {
         // Update the host status in the db
         self.host_collection
             .update_one_within(
-                doc! { "device_id": host_update_status.request_info.device_id },
-                UpdateModifications::Document(doc! { "$set": { "status": status_bson } }),
+                doc! { "device_id": device_id },
+                UpdateModifications::Document(doc! { "$set":
+                    { "status": status_bson, "channel": channel
+                } }),
                 false,
             )
             .await?;
@@ -120,5 +130,113 @@ impl OrchestratorHostUpdatesApi {
             maybe_response_tags: None,
             maybe_headers: None,
         })
+    }
+}
+// Tests:
+// TODO: Separate out into diff dir (in line with repo pattern)
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use anyhow::Result;
+    use db_utils::mongodb::api::MongoDbAPI;
+    use db_utils::schemas::DATABASE_NAME;
+    use mock_utils::host::create_test_host;
+    use mock_utils::mongodb_runner::MongodRunner;
+    use mock_utils::nats_message::NatsMessage;
+    use std::sync::Arc;
+    // use db_utils::schemas::host::Host;
+
+    #[tokio::test]
+    async fn test_handle_host_update() -> Result<()> {
+        let mongod = MongodRunner::run().expect("Failed to run Mongodb Runner");
+        let db_client = mongod
+            .client()
+            .expect("Failed to connect client to Mongodb");
+        let api = OrchestratorHostUpdatesApi::new(&db_client).await?;
+
+        // Insert a test host and hoster (minimal, not strictly required for current logic)
+        let host = create_test_host("test_device_id", None, None, None, None, None);
+        let _host_id = api.host_collection.insert_one_into(host).await?;
+
+        let update_request = HostUpdateRequest {
+            channel: "nixos-unstable".to_string(),
+            device_id: "test_device_id".to_string(),
+        };
+        let msg_payload = serde_json::to_vec(&update_request).unwrap();
+        let msg =
+            Arc::new(NatsMessage::new("HOST.orchestrator.update", msg_payload).into_message());
+        let r = api.handle_host_update(msg).await?;
+
+        if let HostUpdateResult::Success(info) = r.result {
+            assert_eq!(info.request_info.device_id, "test_device_id");
+            assert_eq!(info.request_info.channel, "nixos-unstable");
+            assert!(r.maybe_response_tags.is_some());
+            let tags = r.maybe_response_tags.unwrap();
+            assert!(tags.contains_key(TAG_MAP_PREFIX_DESIGNATED_HOST));
+            assert_eq!(tags[TAG_MAP_PREFIX_DESIGNATED_HOST], "test_device_id");
+        } else {
+            panic!("Expected HostUpdateResult::Success, got something else");
+        }
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_handle_host_update_response() -> Result<()> {
+        let mongod = MongodRunner::run().expect("Failed to run Mongodb Runner");
+        let db_client = mongod
+            .client()
+            .expect("Failed to connect client to Mongodb");
+        let api = OrchestratorHostUpdatesApi::new(&db_client).await?;
+
+        // Insert a test host
+        let mut host = create_test_host("test_device_id", None, None, None, None, None);
+        host.device_id = "test_device_id".to_string();
+        let _host_id = api.host_collection.insert_one_into(host).await?;
+
+        let update_request = HostUpdateRequest {
+            channel: "nixos-unstable".to_string(),
+            device_id: "test_device_id".to_string(),
+        };
+        let response_info = HostUpdateResponseInfo {
+            info: "Update performed successfully".to_string(),
+            request_info: update_request.clone(),
+        };
+        let update_result = HostUpdateResult::Success(response_info.clone());
+        let msg_payload = serde_json::to_vec(&update_result).unwrap();
+        let msg =
+            Arc::new(NatsMessage::new("HOST.orchestrator.status", msg_payload).into_message());
+        let r = api.handle_host_update_response(msg).await?;
+
+        if let HostUpdateResult::Success(info) = r.result {
+            assert_eq!(info.request_info.device_id, "test_device_id");
+            assert_eq!(info.request_info.channel, "nixos-unstable");
+        } else {
+            panic!("Expected HostUpdateResult::Success, got something else");
+        }
+
+        // Check that the host status was updated in the DB
+        let raw_doc = db_client
+            .database(DATABASE_NAME)
+            .collection::<bson::Document>("host")
+            .find_one(bson::doc! { "device_id": "test_device_id" })
+            .await?
+            .expect("Host should exist");
+
+        println!("raw_doc >>>>>>>>>>> {:#?}", raw_doc);
+        assert!(raw_doc.get("status").is_some());
+        assert!(raw_doc.get("channel").is_some());
+        assert_eq!(
+            raw_doc.get("channel").unwrap().as_str().unwrap(),
+            "nixos-unstable"
+        );
+        assert!(raw_doc.get("status").is_some());
+        let status_bson = raw_doc.get("status").unwrap();
+        let status: HostStatus = bson::from_bson(status_bson.clone()).unwrap();
+        assert_eq!(
+            status,
+            HostStatus::Active("Update performed successfully".to_string())
+        );
+
+        Ok(())
     }
 }

--- a/rust/services/hpos_updates/src/orchestrator_api.rs
+++ b/rust/services/hpos_updates/src/orchestrator_api.rs
@@ -1,6 +1,6 @@
 use super::{
-    types::{HostUpdateApiResult, HostUpdateRequest, HostUpdateResponseInfo, HostUpdateResult},
-    HostUpdatesServiceApi, TAG_MAP_PREFIX_DESIGNATED_HOST,
+    types::{HostUpdateApiRequest, HostUpdateInfo, HostUpdateRequest, HostUpdateState},
+    HposUpdatesServiceApi, TAG_MAP_PREFIX_DESIGNATED_HOST,
 };
 use anyhow::Result;
 use async_nats::Message;
@@ -17,14 +17,14 @@ use nats_utils::types::ServiceError;
 use std::{collections::HashMap, fmt::Debug, sync::Arc};
 
 #[derive(Clone, Debug)]
-pub struct OrchestratorHostUpdatesApi {
+pub struct OrchestratorHposUpdatesApi {
     pub host_collection: MongoCollection<Host>,
     pub _hoster_collection: MongoCollection<Hoster>,
 }
 
-impl HostUpdatesServiceApi for OrchestratorHostUpdatesApi {}
+impl HposUpdatesServiceApi for OrchestratorHposUpdatesApi {}
 
-impl OrchestratorHostUpdatesApi {
+impl OrchestratorHposUpdatesApi {
     pub async fn new(client: &MongoDBClient) -> Result<Self> {
         Ok(Self {
             host_collection: Self::init_collection(client, HOST_COLLECTION_NAME).await?,
@@ -36,8 +36,9 @@ impl OrchestratorHostUpdatesApi {
     pub async fn handle_host_update(
         &self,
         msg: Arc<Message>,
-    ) -> Result<HostUpdateApiResult, ServiceError> {
-        let update_request = Self::convert_msg_to_type::<HostUpdateRequest>(msg)?;
+    ) -> Result<HostUpdateApiRequest, ServiceError> {
+        let update_request: HostUpdateRequest =
+            Self::convert_msg_to_type::<HostUpdateRequest>(msg)?;
         log::info!("Orchestrator::handle_host_update: msg={update_request:?}");
 
         // QUESTION: Do we need to retrieve or update data in the Host and/or Hoster collections?
@@ -45,14 +46,13 @@ impl OrchestratorHostUpdatesApi {
 
         let channel = update_request.channel.clone();
         let device_id = update_request.device_id.clone();
-        let info = HostUpdateResponseInfo {
-            info: format!(
+        let info = HostUpdateInfo {
+            context: Some(format!(
                 "Requesting {:?} to preform update on nixos channel {}",
                 update_request.device_id, update_request.channel
-            ),
-            // host_id: ObjectId,
-            // hoster_id: ObjectId,
+            )),
             request_info: update_request,
+            state: HostUpdateState::Pending,
         };
 
         // Create tag map to fwd message onward to designated host
@@ -65,39 +65,55 @@ impl OrchestratorHostUpdatesApi {
             subject_tag_map.values()
         );
 
-        Ok(HostUpdateApiResult {
-            result: HostUpdateResult::Success(info),
+        Ok(HostUpdateApiRequest {
+            info,
             maybe_response_tags: Some(subject_tag_map),
             maybe_headers: None,
         })
     }
 
-    // Invoked on `HOST.orchestrator.status`
+    // Invoked on `HPOS.orchestrator.status`
+    // Automatically published to via the callback in the holo-host-agent hpos-update service
     pub async fn handle_host_update_response(
         &self,
         msg: Arc<Message>,
-    ) -> Result<HostUpdateApiResult, ServiceError> {
-        // Handle the response from holo-host-agent
-        let update_result = Self::convert_msg_to_type::<HostUpdateResult>(msg)?;
+    ) -> Result<HostUpdateApiRequest, ServiceError> {
+        let host_update_info = Self::convert_msg_to_type::<HostUpdateInfo>(msg)?;
+        log::info!("Orchestrator::handle_host_update_response received: msg={host_update_info:?}");
 
-        log::info!("Orchestrator::handle_host_update_response received: msg={update_result:?}");
-
-        let (host_update_status, channel, device_id) = match update_result.clone() {
-            HostUpdateResult::Success(response) => {
-                // TODO: manage any special logic for success case
-                (
-                    HostStatus::Active(response.info),
-                    response.request_info.channel,
-                    response.request_info.device_id,
+        let host_update_status = match host_update_info.state {
+            HostUpdateState::Completed => {
+                // TODO: Add any special logic for success case
+                HostStatus::Active(
+                    (host_update_info
+                        .context
+                        .as_ref()
+                        .unwrap_or(&"Running".to_string()))
+                    .to_string(),
                 )
             }
-            HostUpdateResult::Error(response) => {
-                log::error!("Failed to update host: response_info={:?}", response.info);
-                (
-                    HostStatus::Error(response.info),
-                    response.request_info.channel,
-                    response.request_info.device_id,
+            HostUpdateState::Failed => {
+                log::error!(
+                    "Failed to update host. Reporting error to db. response={:?}",
+                    host_update_info
+                );
+                HostStatus::Error(
+                    (host_update_info
+                        .context
+                        .as_ref()
+                        .unwrap_or(&"Error".to_string()))
+                    .to_string(),
                 )
+            }
+            HostUpdateState::Pending => {
+                log::warn!(
+                    "Received unexpected state in host update response. Reporting error to db. response={:?}",
+                    host_update_info
+                );
+                HostStatus::Error(format!(
+                    "Host Nixos update status reported as still Pending. device_id={}, channel={}",
+                    host_update_info.request_info.device_id, host_update_info.request_info.channel
+                ))
             }
         };
 
@@ -114,6 +130,9 @@ impl OrchestratorHostUpdatesApi {
             )
         })?;
 
+        let device_id = host_update_info.request_info.device_id.clone();
+        let channel = host_update_info.request_info.channel.clone();
+
         // Update the host status in the db
         self.host_collection
             .update_one_within(
@@ -125,118 +144,10 @@ impl OrchestratorHostUpdatesApi {
             )
             .await?;
 
-        Ok(HostUpdateApiResult {
-            result: update_result,
+        Ok(HostUpdateApiRequest {
+            info: host_update_info,
             maybe_response_tags: None,
             maybe_headers: None,
         })
-    }
-}
-// Tests:
-// TODO: Separate out into diff dir (in line with repo pattern)
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use anyhow::Result;
-    use db_utils::mongodb::api::MongoDbAPI;
-    use db_utils::schemas::DATABASE_NAME;
-    use mock_utils::host::create_test_host;
-    use mock_utils::mongodb_runner::MongodRunner;
-    use mock_utils::nats_message::NatsMessage;
-    use std::sync::Arc;
-    // use db_utils::schemas::host::Host;
-
-    #[tokio::test]
-    async fn test_handle_host_update() -> Result<()> {
-        let mongod = MongodRunner::run().expect("Failed to run Mongodb Runner");
-        let db_client = mongod
-            .client()
-            .expect("Failed to connect client to Mongodb");
-        let api = OrchestratorHostUpdatesApi::new(&db_client).await?;
-
-        // Insert a test host and hoster (minimal, not strictly required for current logic)
-        let host = create_test_host("test_device_id", None, None, None, None, None);
-        let _host_id = api.host_collection.insert_one_into(host).await?;
-
-        let update_request = HostUpdateRequest {
-            channel: "nixos-unstable".to_string(),
-            device_id: "test_device_id".to_string(),
-        };
-        let msg_payload = serde_json::to_vec(&update_request).unwrap();
-        let msg =
-            Arc::new(NatsMessage::new("HOST.orchestrator.update", msg_payload).into_message());
-        let r = api.handle_host_update(msg).await?;
-
-        if let HostUpdateResult::Success(info) = r.result {
-            assert_eq!(info.request_info.device_id, "test_device_id");
-            assert_eq!(info.request_info.channel, "nixos-unstable");
-            assert!(r.maybe_response_tags.is_some());
-            let tags = r.maybe_response_tags.unwrap();
-            assert!(tags.contains_key(TAG_MAP_PREFIX_DESIGNATED_HOST));
-            assert_eq!(tags[TAG_MAP_PREFIX_DESIGNATED_HOST], "test_device_id");
-        } else {
-            panic!("Expected HostUpdateResult::Success, got something else");
-        }
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn test_handle_host_update_response() -> Result<()> {
-        let mongod = MongodRunner::run().expect("Failed to run Mongodb Runner");
-        let db_client = mongod
-            .client()
-            .expect("Failed to connect client to Mongodb");
-        let api = OrchestratorHostUpdatesApi::new(&db_client).await?;
-
-        // Insert a test host
-        let mut host = create_test_host("test_device_id", None, None, None, None, None);
-        host.device_id = "test_device_id".to_string();
-        let _host_id = api.host_collection.insert_one_into(host).await?;
-
-        let update_request = HostUpdateRequest {
-            channel: "nixos-unstable".to_string(),
-            device_id: "test_device_id".to_string(),
-        };
-        let response_info = HostUpdateResponseInfo {
-            info: "Update performed successfully".to_string(),
-            request_info: update_request.clone(),
-        };
-        let update_result = HostUpdateResult::Success(response_info.clone());
-        let msg_payload = serde_json::to_vec(&update_result).unwrap();
-        let msg =
-            Arc::new(NatsMessage::new("HOST.orchestrator.status", msg_payload).into_message());
-        let r = api.handle_host_update_response(msg).await?;
-
-        if let HostUpdateResult::Success(info) = r.result {
-            assert_eq!(info.request_info.device_id, "test_device_id");
-            assert_eq!(info.request_info.channel, "nixos-unstable");
-        } else {
-            panic!("Expected HostUpdateResult::Success, got something else");
-        }
-
-        // Check that the host status was updated in the DB
-        let raw_doc = db_client
-            .database(DATABASE_NAME)
-            .collection::<bson::Document>("host")
-            .find_one(bson::doc! { "device_id": "test_device_id" })
-            .await?
-            .expect("Host should exist");
-
-        println!("raw_doc >>>>>>>>>>> {:#?}", raw_doc);
-        assert!(raw_doc.get("status").is_some());
-        assert!(raw_doc.get("channel").is_some());
-        assert_eq!(
-            raw_doc.get("channel").unwrap().as_str().unwrap(),
-            "nixos-unstable"
-        );
-        assert!(raw_doc.get("status").is_some());
-        let status_bson = raw_doc.get("status").unwrap();
-        let status: HostStatus = bson::from_bson(status_bson.clone()).unwrap();
-        assert_eq!(
-            status,
-            HostStatus::Active("Update performed successfully".to_string())
-        );
-
-        Ok(())
     }
 }

--- a/rust/services/hpos_updates/src/orchestrator_api.rs
+++ b/rust/services/hpos_updates/src/orchestrator_api.rs
@@ -1,35 +1,25 @@
-use super::{types::HostUpdateResult, HostUpdatesServiceApi};
+use super::{
+    types::{HostUpdateApiResult, HostUpdateRequest, HostUpdateResponseInfo, HostUpdateResult},
+    HostUpdatesServiceApi, TAG_MAP_PREFIX_DESIGNATED_HOST,
+};
 use anyhow::Result;
-use async_nats::jetstream::ErrorCode;
 use async_nats::Message;
-use bson::{self, doc, oid::ObjectId, DateTime};
+use bson::{self, doc};
 use db_utils::{
-    mongodb::{
-        api::MongoDbAPI,
-        collection::MongoCollection,
-        traits::{IntoIndexes, MutMetadata},
-    },
+    mongodb::{api::MongoDbAPI, collection::MongoCollection},
     schemas::{
-        self,
         host::{Host, HOST_COLLECTION_NAME},
-        workload::{Workload, WORKLOAD_COLLECTION_NAME},
+        hoster::{Hoster, HOSTER_COLLECTION_NAME},
     },
 };
 use mongodb::{options::UpdateModifications, Client as MongoDBClient};
 use nats_utils::types::ServiceError;
-use serde::{Deserialize, Serialize};
-use std::{fmt::Debug, sync::Arc};
-use types::HostUpdateResult;
-
-// HOST.<machine_id>.update
-
-// stream_subject.recipient.action
-/// HOST.orchestrator.<>
+use std::{collections::HashMap, fmt::Debug, sync::Arc};
 
 #[derive(Clone, Debug)]
 pub struct OrchestratorHostUpdatesApi {
-    pub workload_collection: MongoCollection<Workload>,
     pub host_collection: MongoCollection<Host>,
+    pub _hoster_collection: MongoCollection<Hoster>,
 }
 
 impl HostUpdatesServiceApi for OrchestratorHostUpdatesApi {}
@@ -37,23 +27,67 @@ impl HostUpdatesServiceApi for OrchestratorHostUpdatesApi {}
 impl OrchestratorHostUpdatesApi {
     pub async fn new(client: &MongoDBClient) -> Result<Self> {
         Ok(Self {
-            workload_collection: Self::init_collection(client, WORKLOAD_COLLECTION_NAME).await?,
             host_collection: Self::init_collection(client, HOST_COLLECTION_NAME).await?,
+            _hoster_collection: Self::init_collection(client, HOSTER_COLLECTION_NAME).await?,
         })
     }
 
-    //
-    async fn handle_host_update_response(
+    // Invoked on `HOST.orchestrator.status`
+    pub async fn handle_host_update(
         &self,
         msg: Arc<Message>,
-    ) -> Result<HostUpdateResult, ServiceError> {
-        // handle the response from holo-host-agent
-        let host_update_status = match Self::convert_msg_to_type::<HostUpdateResult>(msg)? {
-            HostUpdateResult::Success(mut response_info) => {
-                // do any logic for succss case
+    ) -> Result<HostUpdateApiResult, ServiceError> {
+        let update_request = Self::convert_msg_to_type::<HostUpdateRequest>(msg)?;
+        log::info!("Orchestrator::handle_host_update: msg={update_request:?}");
+
+        // QUESTION: Do we need to retrieve or update data in the Host and/or Hoster collections?
+        // If so, do that logic here...
+
+        let channel = update_request.channel.clone();
+        let device_id = update_request.device_id.clone();
+        let info = HostUpdateResponseInfo {
+            info: format!(
+                "Requesting {:?} to preform update on nixos channel {}",
+                update_request.device_id, update_request.channel
+            ),
+            // host_id: ObjectId,
+            // hoster_id: ObjectId,
+            request_info: update_request,
+        };
+
+        // Create tag map to fwd message onward to designated host
+        let mut subject_tag_map = HashMap::new();
+        subject_tag_map.insert(TAG_MAP_PREFIX_DESIGNATED_HOST.to_string(), device_id);
+
+        log::info!(
+            "Requesting updates on hosts. Channel={:#?}\nDeviceIds={:#?}",
+            channel,
+            subject_tag_map.values()
+        );
+
+        Ok(HostUpdateApiResult {
+            result: HostUpdateResult::Success(info),
+            maybe_response_tags: Some(subject_tag_map),
+            maybe_headers: None,
+        })
+    }
+
+    // Invoked on `HOST.orchestrator.status`
+    pub async fn handle_host_update_response(
+        &self,
+        msg: Arc<Message>,
+    ) -> Result<HostUpdateApiResult, ServiceError> {
+        // Handle the response from holo-host-agent
+        let update_result = Self::convert_msg_to_type::<HostUpdateResult>(msg)?;
+
+        log::info!("Orchestrator::handle_host_update_response received: msg={update_result:?}");
+
+        let host_update_status = match update_result.clone() {
+            HostUpdateResult::Success(response_info) => {
+                // manage any special logic for success case
                 response_info
             }
-            HostUpdateResult::Error(mut response_info) => {
+            HostUpdateResult::Error(response_info) => {
                 log::error!("Failed to update host: response_info={response_info:?}");
                 response_info
             }
@@ -64,7 +98,7 @@ impl OrchestratorHostUpdatesApi {
             host_update_status
         );
 
-        // Update the workload status in the db
+        // Convert the status to be bson compatible (required for mongodb)
         let status_bson = bson::to_bson(&host_update_status).map_err(|e| {
             ServiceError::internal(
                 e.to_string(),
@@ -72,40 +106,19 @@ impl OrchestratorHostUpdatesApi {
             )
         })?;
 
-        // NB: unwrap is safe here because we check if it is set above
+        // Update the host status in the db
         self.host_collection
             .update_one_within(
-                doc! { "_id": host_update_status.device_id },
+                doc! { "device_id": host_update_status.request_info.device_id },
                 UpdateModifications::Document(doc! { "$set": { "status": status_bson } }),
                 false,
             )
             .await?;
 
-        Ok(HostUpdateResult {
-            result: host_update_status,
+        Ok(HostUpdateApiResult {
+            result: update_result,
             maybe_response_tags: None,
             maybe_headers: None,
         })
-    }
-
-    async fn handle_host_update(
-        &self,
-        update_request: HostUpdateRequest,
-    ) -> Result<HostUpdateResult, ServiceError> {
-        // log::info!("Orchestrator::handle_workload_assignment");
-
-        // // Find minimum number of eligible hosts for the new workload
-        // let min_eligible_hosts = self
-        //     .get_min_random_hosts_for_workload(workload.clone())
-        //     .await?;
-
-        // log::debug!(
-        //     "Eligible hosts for new workload. MongodDB Hosts={:?}",
-        //     min_eligible_hosts
-        // );
-
-        // // Assign workload to hosts and create response
-        // self.assign_workload_and_create_response(workload, min_eligible_hosts, target_state)
-        //     .await
     }
 }

--- a/rust/services/hpos_updates/src/orchestrator_api.rs
+++ b/rust/services/hpos_updates/src/orchestrator_api.rs
@@ -25,7 +25,7 @@ pub struct OrchestratorHostUpdatesApi {
 impl HostUpdatesServiceApi for OrchestratorHostUpdatesApi {}
 
 impl OrchestratorHostUpdatesApi {
-    pub async fn new(client: &MongoDBClient) -> Result<Self> {
+    pub async fn new(client: &MongoDBClient) -> HostUpdateApiResult<Self> {
         Ok(Self {
             host_collection: Self::init_collection(client, HOST_COLLECTION_NAME).await?,
             _hoster_collection: Self::init_collection(client, HOSTER_COLLECTION_NAME).await?,

--- a/rust/services/hpos_updates/src/orchestrator_api.rs
+++ b/rust/services/hpos_updates/src/orchestrator_api.rs
@@ -1,0 +1,111 @@
+use super::{types::HostUpdateResult, HostUpdatesServiceApi};
+use anyhow::Result;
+use async_nats::jetstream::ErrorCode;
+use async_nats::Message;
+use bson::{self, doc, oid::ObjectId, DateTime};
+use db_utils::{
+    mongodb::{
+        api::MongoDbAPI,
+        collection::MongoCollection,
+        traits::{IntoIndexes, MutMetadata},
+    },
+    schemas::{
+        self,
+        host::{Host, HOST_COLLECTION_NAME},
+        workload::{Workload, WORKLOAD_COLLECTION_NAME},
+    },
+};
+use mongodb::{options::UpdateModifications, Client as MongoDBClient};
+use nats_utils::types::ServiceError;
+use serde::{Deserialize, Serialize};
+use std::{fmt::Debug, sync::Arc};
+use types::HostUpdateResult;
+
+// HOST.<machine_id>.update
+
+// stream_subject.recipient.action
+/// HOST.orchestrator.<>
+
+#[derive(Clone, Debug)]
+pub struct OrchestratorHostUpdatesApi {
+    pub workload_collection: MongoCollection<Workload>,
+    pub host_collection: MongoCollection<Host>,
+}
+
+impl HostUpdatesServiceApi for OrchestratorHostUpdatesApi {}
+
+impl OrchestratorHostUpdatesApi {
+    pub async fn new(client: &MongoDBClient) -> Result<Self> {
+        Ok(Self {
+            workload_collection: Self::init_collection(client, WORKLOAD_COLLECTION_NAME).await?,
+            host_collection: Self::init_collection(client, HOST_COLLECTION_NAME).await?,
+        })
+    }
+
+    //
+    async fn handle_host_update_response(
+        &self,
+        msg: Arc<Message>,
+    ) -> Result<HostUpdateResult, ServiceError> {
+        // handle the response from holo-host-agent
+        let host_update_status = match Self::convert_msg_to_type::<HostUpdateResult>(msg)? {
+            HostUpdateResult::Success(mut response_info) => {
+                // do any logic for succss case
+                response_info
+            }
+            HostUpdateResult::Error(mut response_info) => {
+                log::error!("Failed to update host: response_info={response_info:?}");
+                response_info
+            }
+        };
+
+        log::debug!(
+            "Received host update response. Status={:?}",
+            host_update_status
+        );
+
+        // Update the workload status in the db
+        let status_bson = bson::to_bson(&host_update_status).map_err(|e| {
+            ServiceError::internal(
+                e.to_string(),
+                Some("Failed to serialize host update status".to_string()),
+            )
+        })?;
+
+        // NB: unwrap is safe here because we check if it is set above
+        self.host_collection
+            .update_one_within(
+                doc! { "_id": host_update_status.device_id },
+                UpdateModifications::Document(doc! { "$set": { "status": status_bson } }),
+                false,
+            )
+            .await?;
+
+        Ok(HostUpdateResult {
+            result: host_update_status,
+            maybe_response_tags: None,
+            maybe_headers: None,
+        })
+    }
+
+    async fn handle_host_update(
+        &self,
+        update_request: HostUpdateRequest,
+    ) -> Result<HostUpdateResult, ServiceError> {
+        // log::info!("Orchestrator::handle_workload_assignment");
+
+        // // Find minimum number of eligible hosts for the new workload
+        // let min_eligible_hosts = self
+        //     .get_min_random_hosts_for_workload(workload.clone())
+        //     .await?;
+
+        // log::debug!(
+        //     "Eligible hosts for new workload. MongodDB Hosts={:?}",
+        //     min_eligible_hosts
+        // );
+
+        // // Assign workload to hosts and create response
+        // self.assign_workload_and_create_response(workload, min_eligible_hosts, target_state)
+        //     .await
+    }
+}

--- a/rust/services/hpos_updates/src/tests/host_api.rs
+++ b/rust/services/hpos_updates/src/tests/host_api.rs
@@ -1,0 +1,17 @@
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use anyhow::Result;
+    use db_utils::mongodb::api::MongoDbAPI;
+    use db_utils::schemas::DATABASE_NAME;
+    use mock_utils::host::create_test_host;
+    use mock_utils::mongodb_runner::MongodRunner;
+    use mock_utils::nats_message::NatsMessage;
+    use std::sync::Arc;
+
+    #[tokio::test]
+    async fn test_handle_host_update() -> Result<()> {
+        // TODO: Implement Host's HPOS Update Service API test
+        Ok(())
+    }
+}

--- a/rust/services/hpos_updates/src/tests/host_api.rs
+++ b/rust/services/hpos_updates/src/tests/host_api.rs
@@ -2,16 +2,61 @@
 mod tests {
     use super::*;
     use anyhow::Result;
-    use db_utils::mongodb::api::MongoDbAPI;
-    use db_utils::schemas::DATABASE_NAME;
-    use mock_utils::host::create_test_host;
-    use mock_utils::mongodb_runner::MongodRunner;
     use mock_utils::nats_message::NatsMessage;
     use std::sync::Arc;
 
     #[tokio::test]
-    async fn test_handle_host_update() -> Result<()> {
-        // TODO: Implement Host's HPOS Update Service API test
+    async fn test_handle_host_update_good_state() -> Result<()> {
+        let api = HostUpdatesApi {};
+
+        let starting_request_info = HostUpdateInfo {
+            request_info: HostUpdateRequest {
+                channel: "nixos-unstable".to_string(),
+                device_id: "test_device_id".to_string(),
+            },
+            state: HostUpdateState::Pending,
+            context: None,
+        };
+
+        let msg_payload = serde_json::to_vec(&starting_request_info).unwrap();
+        let msg = Arc::new(NatsMessage::new("HPOS.host.update", msg_payload).into_message());
+
+        let result = api.handle_host_update_command(msg).await?;
+
+        assert!(
+            result.info.state == HostUpdateState::Completed
+                || result.info.state == HostUpdateState::Failed
+        );
+        assert_eq!(
+            result.info.request_info.device_id,
+            starting_request_info.request_info.device_id
+        );
+        assert_eq!(
+            result.info.request_info.channel,
+            starting_request_info.request_info.channel
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_handle_host_update_response_bad_state() -> Result<()> {
+        let api = HostUpdatesApi {};
+        let completed_info = HostUpdateInfo {
+            request_info: HostUpdateRequest {
+                channel: "nixos-unstable".to_string(),
+                device_id: "test_device_id".to_string(),
+            },
+            state: HostUpdateState::Completed,
+            context: Some("Update performed successfully".to_string()),
+        };
+        let msg_payload = serde_json::to_vec(&completed_info).unwrap();
+        let msg = Arc::new(NatsMessage::new("HPOS.host.status", msg_payload).into_message());
+        let result = api.handle_host_update_command(msg).await?;
+        assert_eq!(result.info.state, HostUpdateState::Completed);
+        assert_eq!(
+            result.info.context,
+            Some("Update performed successfully".to_string())
+        );
         Ok(())
     }
 }

--- a/rust/services/hpos_updates/src/tests/mod.rs
+++ b/rust/services/hpos_updates/src/tests/mod.rs
@@ -1,0 +1,2 @@
+pub mod host_api;
+pub mod orchestrator_api;

--- a/rust/services/hpos_updates/src/tests/orchestrator_api.rs
+++ b/rust/services/hpos_updates/src/tests/orchestrator_api.rs
@@ -1,0 +1,116 @@
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use anyhow::Result;
+    use db_utils::mongodb::api::MongoDbAPI;
+    use db_utils::schemas::DATABASE_NAME;
+    use mock_utils::host::create_test_host;
+    use mock_utils::mongodb_runner::MongodRunner;
+    use mock_utils::nats_message::NatsMessage;
+    use std::sync::Arc;
+    // use db_utils::schemas::host::Host;
+
+    #[tokio::test]
+    async fn test_handle_host_update() -> Result<()> {
+        let mongod = MongodRunner::run().expect("Failed to run Mongodb Runner");
+        let db_client = mongod
+            .client()
+            .expect("Failed to connect client to Mongodb");
+        let api = OrchestratorHposUpdatesApi::new(&db_client).await?;
+
+        let starting_request_info = HostUpdateRequest {
+            channel: "nixos-unstable".to_string(),
+            device_id: "test_device_id".to_string(),
+        };
+
+        // TODO: Remove this once we have a way to test the orchestrator api
+        // Insert a test host and hoster (minimal, not strictly required for current logic)
+        let host = create_test_host("test_device_id", None, None, None, None, None);
+        let _host_id = api.host_collection.insert_one_into(host).await?;
+
+        let update_request = HostUpdateRequest {
+            channel: "nixos-unstable".to_string(),
+            device_id: "test_device_id".to_string(),
+        };
+        let msg_payload = serde_json::to_vec(&update_request).unwrap();
+        let msg =
+            Arc::new(NatsMessage::new("HOST.orchestrator.update", msg_payload).into_message());
+
+        let result = api.handle_host_update(msg).await?;
+
+        assert!(result.maybe_response_tags.is_some());
+        let tags = result.maybe_response_tags.unwrap();
+        assert!(tags.contains_key(TAG_MAP_PREFIX_DESIGNATED_HOST));
+        assert_eq!(tags[TAG_MAP_PREFIX_DESIGNATED_HOST], "test_device_id");
+
+        let ending_request_info = result.info.request_info;
+        assert_eq!(
+            ending_request_info.device_id,
+            starting_request_info.device_id
+        );
+        assert_eq!(ending_request_info.channel, starting_request_info.channel);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_handle_host_update_response() -> Result<()> {
+        let mongod = MongodRunner::run().expect("Failed to run Mongodb Runner");
+        let db_client = mongod
+            .client()
+            .expect("Failed to connect client to Mongodb");
+        let api = OrchestratorHposUpdatesApi::new(&db_client).await?;
+
+        // Insert a test host
+        let mut host = create_test_host("test_device_id", None, None, None, None, None);
+        host.device_id = "test_device_id".to_string();
+        let _host_id = api.host_collection.insert_one_into(host).await?;
+
+        let update_request = HostUpdateRequest {
+            channel: "nixos-unstable".to_string(),
+            device_id: "test_device_id".to_string(),
+        };
+        let response_info = HostUpdateInfo {
+            request_info: update_request.clone(),
+            state: HostUpdateState::Completed,
+            context: Some("Update performed successfully".to_string()),
+        };
+        let update_result = HostUpdateApiRequest {
+            info: response_info.clone(),
+            maybe_response_tags: None,
+            maybe_headers: None,
+        };
+        let msg_payload = serde_json::to_vec(&update_result).unwrap();
+        let msg =
+            Arc::new(NatsMessage::new("HOST.orchestrator.status", msg_payload).into_message());
+        let r = api.handle_host_update_response(msg).await?;
+
+        let ending_request_info = r.info.request_info;
+        assert_eq!(ending_request_info.device_id, update_request.device_id);
+        assert_eq!(ending_request_info.channel, update_request.channel);
+
+        // Check that the host status was updated in the DB
+        let raw_doc = db_client
+            .database(DATABASE_NAME)
+            .collection::<bson::Document>("host")
+            .find_one(bson::doc! { "device_id": "test_device_id" })
+            .await?
+            .expect("Host should exist");
+
+        println!("raw_doc >>>>>>>>>>> {:#?}", raw_doc);
+        assert!(raw_doc.get("status").is_some());
+        assert!(raw_doc.get("channel").is_some());
+        assert_eq!(
+            raw_doc.get("channel").unwrap().as_str().unwrap(),
+            "nixos-unstable"
+        );
+        assert!(raw_doc.get("status").is_some());
+        let status_bson = raw_doc.get("status").unwrap();
+        let status: HostStatus = bson::from_bson(status_bson.clone()).unwrap();
+        assert_eq!(
+            status,
+            HostStatus::Active("Update performed successfully".to_string())
+        );
+
+        Ok(())
+    }
+}

--- a/rust/services/hpos_updates/src/types.rs
+++ b/rust/services/hpos_updates/src/types.rs
@@ -1,0 +1,50 @@
+use bson::oid::ObjectId;
+use nats_utils::types::{EndpointTraits, GetHeaderMap, GetResponse, GetSubjectTags};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HostUpdateRequest {
+    channel: String,
+}
+
+pub struct HostUpdateResponseInfo {
+    pub info: String,
+    pub device_id: ObjectId,
+    pub hoster_id: ObjectId,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum HostUpdateResult {
+    Success(HostUpdateResponseInfo),
+    Error(HostUpdateResponseInfo),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HostUpdateApiResult {
+    pub result: HostUpdateResult,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub maybe_response_tags: Option<HashMap<String, String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub maybe_headers: Option<async_nats::HeaderMap>,
+}
+impl EndpointTraits for HostUpdateApiResult {}
+impl GetSubjectTags for HostUpdateApiResult {
+    fn get_subject_tags(&self) -> HashMap<String, String> {
+        self.maybe_response_tags.clone().unwrap_or_default()
+    }
+}
+impl GetResponse for HostUpdateApiResult {
+    fn get_response(&self) -> bytes::Bytes {
+        let r = self.result.clone();
+        match serde_json::to_vec(&r) {
+            Ok(r) => r.into(),
+            Err(e) => e.to_string().into(),
+        }
+    }
+}
+impl GetHeaderMap for HostUpdateApiResult {
+    fn get_header_map(&self) -> Option<async_nats::HeaderMap> {
+        self.maybe_headers.clone()
+    }
+}

--- a/rust/services/hpos_updates/src/types.rs
+++ b/rust/services/hpos_updates/src/types.rs
@@ -1,17 +1,30 @@
-use bson::oid::ObjectId;
 use nats_utils::types::{EndpointTraits, GetHeaderMap, GetResponse, GetSubjectTags};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+// use bson::oid::ObjectId;
+use strum_macros::AsRefStr;
+
+#[derive(Serialize, Deserialize, Clone, Debug, AsRefStr, strum_macros::Display)]
+#[serde(rename_all = "snake_case")]
+#[strum(serialize_all = "snake_case")]
+pub enum HostUpdateServiceSubjects {
+    Update,
+    Status,
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct HostUpdateRequest {
-    channel: String,
+    pub channel: String,
+    pub device_id: String,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct HostUpdateResponseInfo {
     pub info: String,
-    pub device_id: ObjectId,
-    pub hoster_id: ObjectId,
+    // pub host_id: ObjectId,
+    // pub hoster_id: ObjectId,
+    #[serde(flatten)]
+    pub request_info: HostUpdateRequest,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/rust/services/hpos_updates/src/utils.rs
+++ b/rust/services/hpos_updates/src/utils.rs
@@ -1,0 +1,27 @@
+
+use anyhow::Context;
+use std::process::Stdio;
+
+pub(crate) async fn bash(cmd: &str) -> anyhow::Result<()> {
+    let mut bash_cmd = tokio::process::Command::new("/usr/bin/env");
+    bash_cmd.args(["bash", "-c", cmd]);
+
+    log::trace!("Running bash command: {cmd}...");
+
+    let output = bash_cmd
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .context(format!("Spawning {cmd}..."))?
+        .wait_with_output()
+        .await
+        .context(format!("Waiting for spawned command: {cmd}"))?;
+
+    if !output.status.success() {
+        anyhow::bail!("Error running {bash_cmd:?} yielded non-success status:\n{output:?}");
+    }
+
+    log::info!("Nixos channel update result:\n{output:#?}");
+
+    Ok(())
+}

--- a/rust/services/workload/src/lib.rs
+++ b/rust/services/workload/src/lib.rs
@@ -40,8 +40,6 @@ pub const WORKLOAD_SRV_DESC: &str = "This service handles the flow of Workload r
 // TODO(double-check): this was plural but i believe that's a bug because "assigned_host_0" does not start with "assigned_hosts"
 pub const TAG_MAP_PREFIX_ASSIGNED_HOST: &str = "assigned_host";
 
-pub const WORKLOAD_ORCHESTRATOR_SUBJECT_PREFIX: &str = "orchestrator";
-
 #[async_trait]
 pub trait WorkloadServiceApi
 where

--- a/rust/util_libs/db/Cargo.toml
+++ b/rust/util_libs/db/Cargo.toml
@@ -23,7 +23,6 @@ thiserror = { workspace = true }
 dotenv = { workspace = true }
 mongodb = { workspace = true }
 hpos-hal = { workspace = true }
-hpos-updates = { workspace = true }
 nats_utils = { workspace = true }
 clap = { workspace = true }
 chrono = "0.4.0"

--- a/rust/util_libs/db/Cargo.toml
+++ b/rust/util_libs/db/Cargo.toml
@@ -23,6 +23,7 @@ thiserror = { workspace = true }
 dotenv = { workspace = true }
 mongodb = { workspace = true }
 hpos-hal = { workspace = true }
+hpos-updates = { workspace = true }
 nats_utils = { workspace = true }
 clap = { workspace = true }
 chrono = "0.4.0"

--- a/rust/util_libs/db/src/schemas/host.rs
+++ b/rust/util_libs/db/src/schemas/host.rs
@@ -10,6 +10,20 @@ use crate::mongodb::traits::{IntoIndexes, MutMetadata};
 /// Collection name for host documents
 pub const HOST_COLLECTION_NAME: &str = "host";
 
+/// Host status enum
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+pub enum HostStatus {
+    Active(String), // Host is running and accessible
+    Error(String),  // Host is in an error state (e.g. update failed, etc.)
+}
+
+// Default to Active for now
+// TODO: Make handling of default status more robust
+impl Default for HostStatus {
+    fn default() -> Self {
+        HostStatus::Active("Running".to_string())
+    }
+}
 /// Host document schema representing a hosting device in the system
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct Host {
@@ -34,6 +48,13 @@ pub struct Host {
     pub assigned_hoster: Option<ObjectId>,
     /// List of workloads running on this host
     pub assigned_workloads: Vec<ObjectId>,
+    /// Channel of the host
+    /// TODO: Make this required in the future -- only optional for backwards compatibility
+    #[serde(default)]
+    pub channel: Option<String>,
+    /// Status of the host
+    #[serde(default)]
+    pub status: HostStatus,
 }
 
 impl Default for Host {
@@ -49,6 +70,8 @@ impl Default for Host {
             assigned_workloads: vec![],
             assigned_hoster: None,
             ip_address: None,
+            channel: None,
+            status: HostStatus::default(),
         }
     }
 }

--- a/rust/util_libs/db/src/tests/mongodb.rs
+++ b/rust/util_libs/db/src/tests/mongodb.rs
@@ -1,6 +1,6 @@
 use crate::{
     mongodb::{api::MongoDbAPI, collection::MongoCollection},
-    schemas::{self, metadata::Metadata},
+    schemas::{self, host::HostStatus, metadata::Metadata},
 };
 use anyhow::Result;
 use bson::{self, doc, oid, DateTime};

--- a/rust/util_libs/db/src/tests/mongodb.rs
+++ b/rust/util_libs/db/src/tests/mongodb.rs
@@ -6,7 +6,6 @@ use anyhow::Result;
 use bson::{self, doc, oid, DateTime};
 use dotenv::dotenv;
 use hpos_hal::inventory::HoloInventory;
-use hpos_updates::types::HostUpdateRequest;
 use mock_utils::mongodb_runner::MongodRunner;
 
 #[tokio::test]

--- a/rust/util_libs/db/src/tests/mongodb.rs
+++ b/rust/util_libs/db/src/tests/mongodb.rs
@@ -6,6 +6,7 @@ use anyhow::Result;
 use bson::{self, doc, oid, DateTime};
 use dotenv::dotenv;
 use hpos_hal::inventory::HoloInventory;
+use hpos_updates::types::HostUpdateRequest;
 use mock_utils::mongodb_runner::MongodRunner;
 
 #[tokio::test]
@@ -46,6 +47,8 @@ async fn test_indexing_and_api() -> Result<()> {
             avg_latency: 10,
             assigned_workloads: vec![oid::ObjectId::new()],
             assigned_hoster: Some(oid::ObjectId::new()),
+            channel: None,
+            status: HostStatus::default(),
         }
     }
 


### PR DESCRIPTION
![pipeline](https://github.com/holo-host/holo-host/actions/workflows/pipeline.yml/badge.svg)

- [x] New Feature
- [ ] Bug Fix

### Description
Adds the nats service and clients to support the on-command hpos update feature.  