### PR TITLE
Hot fix workload deployment

### DIFF
--- a/nix/modules/nixos/holo-host-agent.nix
+++ b/nix/modules/nixos/holo-host-agent.nix
@@ -97,6 +97,12 @@ in
       description = "Input flag to determine whether to use private networking. When true, containers are isolated with port forwarding. When false, containers share the host network with dynamic port allocation to avoid conflicts.";
     };
 
+    supportedHolochainVersionsPath = lib.mkOption {
+      type = lib.types.str;
+      default = "./supported-holochain-versions.json";
+      description = "Path to the supported Holochain versions config file.";
+    };
+
   };
 
   config = lib.mkIf cfg.enable {
@@ -135,6 +141,7 @@ in
           NATS_LISTEN_PORT = builtins.toString cfg.nats.listenPort;
           NIX_REMOTE = "daemon";
           IS_CONTAINER_ON_PRIVATE_NETWORK = builtins.toString cfg.containerPrivateNetwork;
+          HOLOCHAIN_VERSION_CONFIG_PATH = cfg.supportedHolochainVersionsPath;
         }
         // lib.attrsets.optionalAttrs (cfg.nats.url != null) {
           NATS_URL = cfg.nats.url;

--- a/rust/services/workload/src/orchestrator_api.rs
+++ b/rust/services/workload/src/orchestrator_api.rs
@@ -307,7 +307,7 @@ impl OrchestratorWorkloadApi {
         match workload.status.actual {
             WorkloadState::Reported => {
                 log::debug!("Detected new workload to assign. Workload={:#?}", workload);
-                self.handle_workload_assignment(workload, WorkloadState::Assigned)
+                self.handle_workload_assignment(workload)
                     .await
             }
             WorkloadState::Updated => {
@@ -348,7 +348,6 @@ impl OrchestratorWorkloadApi {
     async fn handle_workload_assignment(
         &self,
         workload: Workload,
-        target_state: WorkloadState,
     ) -> Result<WorkloadApiResult, ServiceError> {
         log::info!("Orchestrator::handle_workload_assignment");
 
@@ -363,7 +362,7 @@ impl OrchestratorWorkloadApi {
         );
 
         // Assign workload to hosts and create response
-        self.assign_workload_and_create_response(workload, min_eligible_hosts, target_state)
+        self.assign_workload_and_create_response(workload, min_eligible_hosts)
             .await
     }
 
@@ -375,7 +374,7 @@ impl OrchestratorWorkloadApi {
 
         // Fetch current hosts and remove workload from them
         self.remove_workload_from_hosts(workload._id).await?;
-        self.handle_workload_assignment(workload, WorkloadState::Updated)
+        self.handle_workload_assignment(workload)
             .await
     }
 
@@ -609,7 +608,6 @@ impl OrchestratorWorkloadApi {
         &self,
         workload: Workload,
         min_eligible_hosts: Vec<HostIdJSON>,
-        target_state: WorkloadState,
     ) -> Result<WorkloadApiResult, ServiceError> {
         // Assign workload to minimum required number of eligible hosts
         let min_eligible_host_ids: Vec<ObjectId> =
@@ -622,7 +620,7 @@ impl OrchestratorWorkloadApi {
         let new_status = WorkloadStatus {
             id: Some(workload._id),
             desired: WorkloadState::Running,
-            actual: target_state,
+            actual: WorkloadState::Assigned,
             payload: Default::default(),
         };
 

--- a/rust/util_libs/db/Cargo.toml
+++ b/rust/util_libs/db/Cargo.toml
@@ -41,4 +41,6 @@ mock_utils = { workspace = true }
 ctor = "0.2"
 
 [features]
+default = ["clap"]
+clap = []
 tests_integration_mongodb = []

--- a/rust/util_libs/db/src/schemas/workload.rs
+++ b/rust/util_libs/db/src/schemas/workload.rs
@@ -2,7 +2,9 @@ use anyhow::Result;
 use bson::{doc, oid::ObjectId, Bson, DateTime, Document};
 use mongodb::options::IndexOptions;
 use semver::{BuildMetadata, Prerelease};
+use serde::de::{self, Deserializer};
 use serde::{Deserialize, Serialize};
+use serde_json::Value as JsonValue;
 use std::collections::HashMap;
 use std::path::PathBuf;
 use strum::{EnumDiscriminants, EnumString, FromRepr};
@@ -135,8 +137,84 @@ impl std::fmt::Display for HappBinaryFormat {
     }
 }
 
+#[derive(Serialize, Clone, Debug)]
+#[cfg_attr(feature = "clap", derive(clap::Args))]
+pub struct WorkloadManifestHolochainDhtV1 {
+    #[cfg_attr(feature = "clap", arg(long, value_parser = parse_happ_binary))]
+    pub happ_binary: HappBinaryFormat,
+
+    #[cfg_attr(feature = "clap", arg(long, value_delimiter = ','))]
+    pub network_seed: Option<String>,
+
+    #[cfg_attr(feature = "clap", arg(long, value_delimiter = ',', value_parser = parse_key_val::<String, String>))]
+    pub memproof: Option<HashMap<String, String>>,
+
+    #[cfg_attr(feature = "clap", arg(long, value_delimiter = ','))]
+    pub bootstrap_server_url: Option<Url>,
+
+    #[cfg_attr(feature = "clap", arg(long, value_delimiter = ','))]
+    pub signal_server_url: Option<Url>,
+
+    #[cfg_attr(feature = "clap", arg(long, value_delimiter = ','))]
+    pub stun_server_urls: Option<Vec<Url>>,
+
+    #[cfg_attr(feature = "clap", arg(long, value_delimiter = ','))]
+    pub holochain_feature_flags: Option<Vec<String>>,
+
+    #[cfg_attr(feature = "clap", arg(long, value_delimiter = ','))]
+    pub holochain_version: Option<String>,
+
+    #[cfg_attr(feature = "clap", arg(long))]
+    pub http_gw_enable: bool,
+
+    #[cfg_attr(feature = "clap", arg(long))]
+    pub http_gw_allowed_fns: Option<Vec<String>>,
+}
+
+impl<'de> Deserialize<'de> for WorkloadManifestHolochainDhtV1 {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let mut map: HashMap<String, JsonValue> = Deserialize::deserialize(deserializer)?;
+
+        let happ_binary = if let Some(hb) = map.remove("happ_binary") {
+            serde_json::from_value(hb).map_err(de::Error::custom)?
+        } else if let Some(url) = map.remove("happ_binary_url") {
+            let url: Url = serde_json::from_value(url).map_err(de::Error::custom)?;
+            HappBinaryFormat::HappBinaryUrl(url)
+        } else {
+            return Err(de::Error::missing_field("happ_binary or happ_binary_url"));
+        };
+
+        macro_rules! pop_field {
+            ($field:literal, $ty:ty) => {
+                map.remove($field)
+                    .map(|v| serde_json::from_value::<$ty>(v).map_err(de::Error::custom))
+                    .transpose()?
+            };
+        }
+
+        Ok(WorkloadManifestHolochainDhtV1 {
+            happ_binary,
+            network_seed: pop_field!("network_seed", String),
+            memproof: pop_field!("memproof", HashMap<String, String>),
+            bootstrap_server_url: pop_field!("bootstrap_server_url", Url),
+            signal_server_url: pop_field!("signal_server_url", Url),
+            stun_server_urls: pop_field!("stun_server_urls", Vec<Url>),
+            holochain_feature_flags: pop_field!("holochain_feature_flags", Vec<String>),
+            holochain_version: pop_field!("holochain_version", String),
+            http_gw_enable: pop_field!("http_gw_enable", bool).unwrap_or(false),
+            http_gw_allowed_fns: pop_field!("http_gw_allowed_fns", Vec<String>),
+        })
+    }
+}
+
 /// Parse into the `HappBinaryFormat` from the clap cli arg (str)
-fn parse_happ_binary(s: &str) -> Result<HappBinaryFormat, Box<dyn std::error::Error + Send + Sync + 'static>> {
+#[cfg(feature = "clap")]
+fn parse_happ_binary(
+    s: &str,
+) -> Result<HappBinaryFormat, Box<dyn std::error::Error + Send + Sync + 'static>> {
     if s.starts_with("http://") || s.starts_with("https://") {
         let url = Url::parse(s)?;
         Ok(HappBinaryFormat::HappBinaryUrl(url))
@@ -144,30 +222,6 @@ fn parse_happ_binary(s: &str) -> Result<HappBinaryFormat, Box<dyn std::error::Er
         // assume (for now) that it's a blake3 hash if it's not a valid Url
         Ok(HappBinaryFormat::HappBinaryBlake3Hash(s.to_string()))
     }
-}
-
-#[derive(Serialize, Deserialize, Clone, Debug, clap::Args)]
-pub struct WorkloadManifestHolochainDhtV1 {
-    #[arg(long, value_parser = parse_happ_binary)]
-    pub happ_binary: HappBinaryFormat,
-    #[arg(long, value_delimiter = ',')]
-    pub network_seed: Option<String>,
-    #[arg(long, value_delimiter = ',', value_parser = parse_key_val::<String, String>)]
-    pub memproof: Option<HashMap<String, String>>,
-    #[arg(long, value_delimiter = ',')]
-    pub bootstrap_server_url: Option<Url>,
-    #[arg(long, value_delimiter = ',')]
-    pub signal_server_url: Option<Url>,
-    #[arg(long, value_delimiter = ',')]
-    pub stun_server_urls: Option<Vec<Url>>,
-    #[arg(long, value_delimiter = ',')]
-    pub holochain_feature_flags: Option<Vec<String>>,
-    #[arg(long, value_delimiter = ',')]
-    pub holochain_version: Option<String>,
-    #[arg(long)]
-    pub http_gw_enable: bool,
-    #[arg(long)]
-    pub http_gw_allowed_fns: Option<Vec<String>>,
 }
 
 /// Parse a single key-value pair


### PR DESCRIPTION
![pipeline](https://github.com/holo-host/holo-host/actions/workflows/pipeline.yml/badge.svg)

- [x] New Feature
- [x] Bug Fix

### Description
 - fix: adds backward compatibility for the `happ_binary` field in the `workload` schema when using a json/web-client.
 - feature: adds in the nix configuration to support a default hc file
